### PR TITLE
cborattr: Fix conversion between cbortype and cborattr

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -51,6 +51,7 @@ valid_attr_type(CborType ct, CborAttrType at)
         if (ct == CborBooleanType) {
             return 1;
         }
+	break;
 #if FLOAT_SUPPORT
     case CborAttrFloatType:
         if (ct == CborFloatType) {


### PR DESCRIPTION
Add missing break statement to Boolean type.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>