### PR TITLE
[DNM] upmerge: synchronize up to mynewt-mcumgr 607995c (--allow-unrelated-histories)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+.app.db
+.app
+bin
+obj
+tags
+.gdb_history
+.gdb_out
+.gdb_cmds
+.gdbinit
+*~
+.DS_Store
+*.swp
+*.swo
+*.bak
+docs/html
+docs/latex
+cscope.*
+*.tags

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is mcumgr, version 0.0.1
 mcumgr is a management library for 32-bit MCUs.   The goal of mcumgr is to
 define a common management infrastructure with pluggable transport and encoding
 components.  In addition, mcumgr provides definitions and handlers for some
-core commands: image management, file system management, and OS managment.
+core commands: image management, file system management, and OS management.
 
 mcumgr is operating system and hardware independent.  It relies on hardware
 porting layers from the operating system it runs on.  Currently, mcumgr runs on
@@ -112,14 +112,10 @@ see the comments at the top of `smp/include/smp/smp.h`.
 ## Supported transports
 
 The mcumgr project defines two transports:
-    * SMP/Console
-    * SMP/Bluetooth
+* [SMP/Console](transport/smp-console.md)
+* [SMP/Bluetooth](transport/smp-bluetooth.md)
 
-Particulars of these transports are specified in the following documents:
-    * SMP/Console: `transports/smp-console.md`
-    * SMP/Bluetooth: `transports/smp-bluetooth.md`
-
-Implementations, being hardware- and OS-specified, are not included.
+Implementations, being hardware- and OS-specific, are not included.
 
 ## Browsing
 
@@ -127,12 +123,12 @@ Information and documentation for mcumgr is stored within the source.
 
 For more information in the source, here are some pointers:
 
-- [cborattr](https://github.com/apache/mynewt-mcumgr/tree/master/cborattr): Used for parsing incoming mcumgr requests.  Destructures mcumgr packets and populates corresponding field variables.
-- [cmd](https://github.com/apache/mynewt-mcumgr/tree/master/cmd): Built-in command handlers for the core mcumgr commands.
-- [ext](https://github.com/apache/mynewt-mcumgr/tree/master/ext): Third-party libraries that mcumgr depends on.
-- [mgmt](https://github.com/apache/mynewt-mcumgr/tree/master/mgmt): Code implementing the `mgmt` layer of mcumgr.
-- [samples](https://github.com/apache/mynewt-mcumgr/tree/master/samples): Sample applications utilizing mcumgr.
-- [smp](https://github.com/apache/mynewt-mcumgr/tree/master/smp): The built-in transfer encoding: Simple management protocol.
+- [cborattr](cborattr): Used for parsing incoming mcumgr requests.  Destructures mcumgr packets and populates corresponding field variables.
+- [cmd](cmd): Built-in command handlers for the core mcumgr commands.
+- [ext](ext): Third-party libraries that mcumgr depends on.
+- [mgmt](mgmt): Code implementing the `mgmt` layer of mcumgr.
+- [samples](samples): Sample applications utilizing mcumgr.
+- [smp](smp): The built-in transfer encoding: Simple management protocol.
 
 ## Joining
 

--- a/cborattr/pkg.yml
+++ b/cborattr/pkg.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: cborattr 
+pkg.description: CBOR encoding/decoding library 
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "encoding/tinycbor"
+
+pkg.cflags.FLOAT_USER: -DFLOAT_SUPPORT

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -51,6 +51,7 @@ valid_attr_type(CborType ct, CborAttrType at)
         if (ct == CborBooleanType) {
             return 1;
         }
+	break;
 #if FLOAT_SUPPORT
     case CborAttrFloatType:
         if (ct == CborFloatType) {

--- a/cborattr/syscfg.yml
+++ b/cborattr/syscfg.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: mgmt/imgmgr
+
+syscfg.defs:
+    CBORATTR_MAX_SIZE:
+        description: 'The maximum size of a CBOR attribute during decoding'
+        value: 512

--- a/cborattr/test/pkg.yml
+++ b/cborattr/test/pkg.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: cborattr/test
+pkg.type: unittest
+pkg.description: "CBOR attr unit tests."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@mynewt-mcumgr/ext/tinycbor'
+    - '@mynewt-mcumgr/cborattr'
+
+pkg.deps.SELFTEST:
+    - sys/console/stub

--- a/cborattr/test/src/test_cborattr.c
+++ b/cborattr/test/src/test_cborattr.c
@@ -17,40 +17,33 @@
  * under the License.
  */
 
-#ifndef H_IMG_MGMT_
-#define H_IMG_MGMT_
+#include "sysinit/sysinit.h"
+#include "syscfg/syscfg.h"
+#include "testutil/testutil.h"
+#include "test_cborattr.h"
 
-#include <inttypes.h>
-struct image_version;
+TEST_SUITE(test_cborattr_suite)
+{
+    test_cborattr_decode1();
+    test_cborattr_decode_partial();
+    test_cborattr_decode_simple();
+    test_cborattr_decode_object();
+    test_cborattr_decode_int_array();
+    test_cborattr_decode_bool_array();
+    test_cborattr_decode_string_array();
+    test_cborattr_decode_object_array();
+    test_cborattr_decode_unnamed_array();
+    test_cborattr_decode_substring_key();
+}
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#if MYNEWT_VAL(SELFTEST)
+int
+main(int argc, char **argv)
+{
+    sysinit();
 
-/**
- * Command IDs for image management group.
- */
-#define IMG_MGMT_ID_STATE           0
-#define IMG_MGMT_ID_UPLOAD          1
-#define IMG_MGMT_ID_FILE            2
-#define IMG_MGMT_ID_CORELIST        3
-#define IMG_MGMT_ID_CORELOAD        4
-#define IMG_MGMT_ID_ERASE           5
+    test_cborattr_suite();
 
-/*
- * IMG_MGMT_ID_UPLOAD statuses.
- */
-#define IMG_MGMT_ID_UPLOAD_STATUS_START         0
-#define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING       1
-#define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE      2
-
-/**
- * @brief Registers the image management command handler group.
- */ 
-void img_mgmt_register_group(void);
-
-#ifdef __cplusplus
+    return tu_any_failed;
 }
 #endif
-
-#endif /* H_IMG_MGMT_ */

--- a/cborattr/test/src/test_cborattr.h
+++ b/cborattr/test/src/test_cborattr.h
@@ -16,41 +16,42 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#ifndef TEST_CBORATTR_H
+#define TEST_CBORATTR_H
 
-#ifndef H_IMG_MGMT_
-#define H_IMG_MGMT_
-
-#include <inttypes.h>
-struct image_version;
+#include <assert.h>
+#include <string.h>
+#include "testutil/testutil.h"
+#include "test_cborattr.h"
+#include "tinycbor/cbor.h"
+#include "cborattr/cborattr.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/**
- * Command IDs for image management group.
+/*
+ * Returns test data.
  */
-#define IMG_MGMT_ID_STATE           0
-#define IMG_MGMT_ID_UPLOAD          1
-#define IMG_MGMT_ID_FILE            2
-#define IMG_MGMT_ID_CORELIST        3
-#define IMG_MGMT_ID_CORELOAD        4
-#define IMG_MGMT_ID_ERASE           5
+const uint8_t *test_str1(int *len);
 
 /*
- * IMG_MGMT_ID_UPLOAD statuses.
+ * Testcases
  */
-#define IMG_MGMT_ID_UPLOAD_STATUS_START         0
-#define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING       1
-#define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE      2
-
-/**
- * @brief Registers the image management command handler group.
- */ 
-void img_mgmt_register_group(void);
+TEST_CASE_DECL(test_cborattr_decode1);
+TEST_CASE_DECL(test_cborattr_decode_partial);
+TEST_CASE_DECL(test_cborattr_decode_simple);
+TEST_CASE_DECL(test_cborattr_decode_object);
+TEST_CASE_DECL(test_cborattr_decode_int_array);
+TEST_CASE_DECL(test_cborattr_decode_bool_array);
+TEST_CASE_DECL(test_cborattr_decode_string_array);
+TEST_CASE_DECL(test_cborattr_decode_object_array);
+TEST_CASE_DECL(test_cborattr_decode_unnamed_array);
+TEST_CASE_DECL(test_cborattr_decode_substring_key);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* H_IMG_MGMT_ */
+#endif /* TEST_CBORATTR_H */
+

--- a/cborattr/test/src/test_cborattr_utils.c
+++ b/cborattr/test/src/test_cborattr_utils.c
@@ -17,40 +17,19 @@
  * under the License.
  */
 
-#ifndef H_IMG_MGMT_
-#define H_IMG_MGMT_
-
-#include <inttypes.h>
-struct image_version;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * Command IDs for image management group.
- */
-#define IMG_MGMT_ID_STATE           0
-#define IMG_MGMT_ID_UPLOAD          1
-#define IMG_MGMT_ID_FILE            2
-#define IMG_MGMT_ID_CORELIST        3
-#define IMG_MGMT_ID_CORELOAD        4
-#define IMG_MGMT_ID_ERASE           5
-
+#include "test_cborattr.h"
 /*
- * IMG_MGMT_ID_UPLOAD statuses.
+ * {"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}
  */
-#define IMG_MGMT_ID_UPLOAD_STATUS_START         0
-#define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING       1
-#define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE      2
+static const uint8_t test_data1[] = {
+    0xa5, 0x61, 0x61, 0x61, 0x41, 0x61, 0x62, 0x61,
+    0x42, 0x61, 0x63, 0x61, 0x43, 0x61, 0x64, 0x61,
+    0x44, 0x61, 0x65, 0x61, 0x45
+};
 
-/**
- * @brief Registers the image management command handler group.
- */ 
-void img_mgmt_register_group(void);
-
-#ifdef __cplusplus
+const uint8_t *
+test_str1(int *len)
+{
+    *len = sizeof(test_data1);
+    return (test_data1);
 }
-#endif
-
-#endif /* H_IMG_MGMT_ */

--- a/cborattr/test/src/testcases/cborattr_decode1.c
+++ b/cborattr/test/src/testcases/cborattr_decode1.c
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Simple decoding.
+ */
+TEST_CASE(test_cborattr_decode1)
+{
+    const uint8_t *data;
+    int len;
+    int rc;
+    char test_str_a[4] = { '\0' };
+    char test_str_b[4] = { '\0' };
+    char test_str_c[4] = { '\0' };
+    char test_str_d[4] = { '\0' };
+    char test_str_e[4] = { '\0' };
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_a,
+            .len = sizeof(test_str_a),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "b",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_b,
+            .len = sizeof(test_str_b),
+            .nodefault = true
+            },
+        [2] = {
+            .attribute = "c",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_c,
+            .len = sizeof(test_str_c),
+            .nodefault = true
+            },
+        [3] = {
+            .attribute = "d",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_d,
+            .len = sizeof(test_str_d),
+            .nodefault = true,
+            },
+        [4] = {
+            .attribute = "e",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_e,
+            .len = sizeof(test_str_e),
+            .nodefault = true,
+        },
+        [5] = {
+            .attribute = NULL
+        }
+    };
+
+    data = test_str1(&len);
+    rc = cbor_read_flat_attrs(data, len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(!strcmp(test_str_a, "A"));
+    TEST_ASSERT(!strcmp(test_str_b, "B"));
+    TEST_ASSERT(!strcmp(test_str_c, "C"));
+    TEST_ASSERT(!strcmp(test_str_d, "D"));
+    TEST_ASSERT(!strcmp(test_str_e, "E"));
+}

--- a/cborattr/test/src/testcases/cborattr_decode_bool_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_bool_array.c
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_bool_array(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: [true,true,false]
+     */
+    cbor_encode_text_stringz(&data, "a");
+
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+    cbor_encode_boolean(&array, true);
+    cbor_encode_boolean(&array, true);
+    cbor_encode_boolean(&array, false);
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * array of booleans
+ */
+TEST_CASE(test_cborattr_decode_bool_array)
+{
+    int rc;
+    bool arr_data[5];
+    int arr_cnt = 0;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrBooleanType,
+            .addr.array.arr.booleans.store = arr_data,
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_bool_array();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 3);
+    TEST_ASSERT(arr_data[0] == true);
+    TEST_ASSERT(arr_data[1] == true);
+    TEST_ASSERT(arr_data[2] == false);
+}

--- a/cborattr/test/src/testcases/cborattr_decode_int_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_int_array.c
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_int_array(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: [1,2,33,15,-4]
+     */
+    cbor_encode_text_stringz(&data, "a");
+
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+    cbor_encode_int(&array, 1);
+    cbor_encode_int(&array, 2);
+    cbor_encode_int(&array, 33);
+    cbor_encode_int(&array, 15);
+    cbor_encode_int(&array, -4);
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * integer array
+ */
+TEST_CASE(test_cborattr_decode_int_array)
+{
+    int rc;
+    int64_t arr_data[5];
+    int64_t b_int;
+    int arr_cnt = 0;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrIntegerType,
+            .addr.array.arr.integers.store = arr_data,
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "b",
+            .type = CborAttrIntegerType,
+            .addr.integer = &b_int,
+            .dflt.integer = 1
+        },
+        [2] = {
+            .attribute = NULL
+        }
+    };
+    struct cbor_attr_t test_attrs_small[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrIntegerType,
+            .addr.array.arr.integers.store = arr_data,
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = 1,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "b",
+            .type = CborAttrIntegerType,
+            .addr.integer = &b_int,
+            .dflt.integer = 1
+        },
+        [2] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_int_array();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 5);
+    TEST_ASSERT(arr_data[0] == 1);
+    TEST_ASSERT(arr_data[1] == 2);
+    TEST_ASSERT(arr_data[2] == 33);
+    TEST_ASSERT(arr_data[3] == 15);
+    TEST_ASSERT(arr_data[4] == -4);
+    TEST_ASSERT(b_int == 1);
+
+    memset(arr_data, 0, sizeof(arr_data));
+    b_int = 0;
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs_small);
+    TEST_ASSERT(rc == CborErrorDataTooLarge);
+    TEST_ASSERT(arr_cnt == 1);
+    TEST_ASSERT(arr_data[0] == 1);
+    TEST_ASSERT(arr_data[1] == 0);
+    TEST_ASSERT(b_int == 1);
+}

--- a/cborattr/test/src/testcases/cborattr_decode_obj_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_obj_array.c
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_obj_array(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+    CborEncoder obj;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: [{ n:"a", v:1}, {n:"b", v:2} ]
+     */
+    cbor_encode_text_stringz(&data, "a");
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+
+    cbor_encoder_create_map(&array, &obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&obj, "n");
+    cbor_encode_text_stringz(&obj, "a");
+    cbor_encode_text_stringz(&obj, "v");
+    cbor_encode_int(&obj, 1);
+    cbor_encoder_close_container(&array, &obj);
+
+    cbor_encoder_create_map(&array, &obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&obj, "n");
+    cbor_encode_text_stringz(&obj, "b");
+    cbor_encode_text_stringz(&obj, "v");
+    cbor_encode_int(&obj, 2);
+    cbor_encoder_close_container(&array, &obj);
+
+    cbor_encoder_close_container(&data, &array);
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * object array
+ */
+TEST_CASE(test_cborattr_decode_obj_array)
+{
+    int rc;
+    char arr_data[4];
+    int arr_cnt;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrNullType,
+            .addr.array.arr.objects.base = arr_data,
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = 4,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_obj_array();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 2);
+}

--- a/cborattr/test/src/testcases/cborattr_decode_object.c
+++ b/cborattr/test/src/testcases/cborattr_decode_object.c
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_data(void)
+{
+    CborEncoder test_data;
+    CborEncoder sub_obj;
+
+    test_cbor_len = 0;
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+    cbor_encoder_create_map(&test_encoder, &test_data, CborIndefiniteLength);
+
+    /*
+     * p: { bm : 7 }
+     */
+    cbor_encode_text_stringz(&test_data, "p");
+
+    cbor_encoder_create_map(&test_data, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&test_data, "bm");
+    cbor_encode_int(&test_data, 7);
+    cbor_encoder_close_container(&test_data, &sub_obj);
+
+    cbor_encoder_close_container(&test_encoder, &test_data);
+}
+
+static void
+test_encode_data_complex(void)
+{
+    CborEncoder test_data;
+    CborEncoder sub_obj;
+    CborEncoder sub_sub_obj;
+
+    test_cbor_len = 0;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+    cbor_encoder_create_map(&test_encoder, &test_data, CborIndefiniteLength);
+
+    /*
+     * p: { bm : 7 }, c: { d : { i : 1 } }, a: 3
+     */
+    cbor_encode_text_stringz(&test_data, "p");
+
+    cbor_encoder_create_map(&test_data, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&test_data, "bm");
+    cbor_encode_int(&test_data, 7);
+    cbor_encoder_close_container(&test_data, &sub_obj);
+
+    cbor_encode_text_stringz(&test_data, "c");
+    cbor_encoder_create_map(&test_data, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&sub_obj, "d");
+
+    cbor_encoder_create_map(&sub_obj, &sub_sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&sub_sub_obj, "i");
+    cbor_encode_int(&sub_sub_obj, 1);
+    cbor_encoder_close_container(&sub_obj, &sub_sub_obj);
+    cbor_encoder_close_container(&test_data, &sub_obj);
+
+    cbor_encode_text_stringz(&test_data, "a");
+    cbor_encode_int(&test_data, 3);
+
+    cbor_encoder_close_container(&test_encoder, &test_data);
+}
+
+/*
+ * Simple decoding.
+ */
+TEST_CASE(test_cborattr_decode_object)
+{
+    int rc;
+    int64_t bm_val = 0;
+    struct cbor_attr_t test_sub_attr_bm[] = {
+        [0] = {
+            .attribute = "bm",
+            .type = CborAttrIntegerType,
+            .addr.integer = &bm_val,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "p",
+            .type = CborAttrObjectType,
+            .addr.obj = test_sub_attr_bm,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+    int64_t a_val = 0;
+    int64_t i_val = 0;
+    struct cbor_attr_t test_sub_sub_attr[] = {
+        [0] = {
+            .attribute = "i",
+            .type = CborAttrIntegerType,
+            .addr.integer = &i_val,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+    struct cbor_attr_t test_sub_attr_d[] = {
+        [0] = {
+            .attribute = "d",
+            .type = CborAttrObjectType,
+            .addr.obj = test_sub_sub_attr,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+    struct cbor_attr_t test_attr_complex[] = {
+        [0] = {
+            .attribute = "c",
+            .type = CborAttrObjectType,
+            .addr.obj = test_sub_attr_d,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "a",
+            .type = CborAttrIntegerType,
+            .addr.integer = &a_val,
+            .nodefault = true
+        },
+        [2] = {
+            .attribute = "p",
+            .type = CborAttrObjectType,
+            .addr.obj = test_sub_attr_bm,
+            .nodefault = true
+        },
+        [3] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_data();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(bm_val == 7);
+
+    test_encode_data_complex();
+
+    bm_val = 0;
+    i_val = 0;
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attr_complex);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(bm_val == 7);
+    TEST_ASSERT(i_val == 1);
+}

--- a/cborattr/test/src/testcases/cborattr_decode_object_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_object_array.c
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_object_array(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+    CborEncoder sub_obj;
+
+    test_cbor_len = 0;
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: [ { h:"str1"}, {h:"2str"}, {h:"str3"}]
+     */
+    cbor_encode_text_stringz(&data, "a");
+
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+
+    cbor_encoder_create_map(&array, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&sub_obj, "h");
+    cbor_encode_text_stringz(&sub_obj, "str1");
+    cbor_encoder_close_container(&array, &sub_obj);
+
+    cbor_encoder_create_map(&array, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&sub_obj, "h");
+    cbor_encode_text_stringz(&sub_obj, "2str");
+    cbor_encoder_close_container(&array, &sub_obj);
+
+    cbor_encoder_create_map(&array, &sub_obj, CborIndefiniteLength);
+    cbor_encode_text_stringz(&sub_obj, "h");
+    cbor_encode_text_stringz(&sub_obj, "str3");
+    cbor_encoder_close_container(&array, &sub_obj);
+
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * object array
+ */
+TEST_CASE(test_cborattr_decode_object_array)
+{
+    int rc;
+    struct h_obj {
+        char h_data[32];
+    } arr_objs[5];
+    int arr_cnt = 0;
+    struct cbor_attr_t sub_attr[] = {
+        [0] = {
+            .attribute = "h",
+            .type = CborAttrTextStringType,
+            CBORATTR_STRUCT_OBJECT(struct h_obj, h_data),
+            .len = sizeof(arr_objs[0].h_data)
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            CBORATTR_STRUCT_ARRAY(arr_objs, sub_attr, &arr_cnt),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_object_array();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 3);
+    TEST_ASSERT(!strcmp(arr_objs[0].h_data, "str1"));
+    TEST_ASSERT(!strcmp(arr_objs[1].h_data, "2str"));
+    TEST_ASSERT(!strcmp(arr_objs[2].h_data, "str3"));
+}

--- a/cborattr/test/src/testcases/cborattr_decode_partial.c
+++ b/cborattr/test/src/testcases/cborattr_decode_partial.c
@@ -16,41 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-#ifndef H_IMG_MGMT_
-#define H_IMG_MGMT_
-
-#include <inttypes.h>
-struct image_version;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * Command IDs for image management group.
- */
-#define IMG_MGMT_ID_STATE           0
-#define IMG_MGMT_ID_UPLOAD          1
-#define IMG_MGMT_ID_FILE            2
-#define IMG_MGMT_ID_CORELIST        3
-#define IMG_MGMT_ID_CORELOAD        4
-#define IMG_MGMT_ID_ERASE           5
+#include "test_cborattr.h"
 
 /*
- * IMG_MGMT_ID_UPLOAD statuses.
+ * Simple decoding. Only have key for one of the key/value pairs.
  */
-#define IMG_MGMT_ID_UPLOAD_STATUS_START         0
-#define IMG_MGMT_ID_UPLOAD_STATUS_ONGOING       1
-#define IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE      2
+TEST_CASE(test_cborattr_decode_partial)
+{
+    const uint8_t *data;
+    int len;
+    int rc;
+    char test_str_b[4] = { '\0' };
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "b",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_b,
+            .len = sizeof(test_str_b),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
 
-/**
- * @brief Registers the image management command handler group.
- */ 
-void img_mgmt_register_group(void);
-
-#ifdef __cplusplus
+    data = test_str1(&len);
+    rc = cbor_read_flat_attrs(data, len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(!strcmp(test_str_b, "B"));
 }
-#endif
-
-#endif /* H_IMG_MGMT_ */

--- a/cborattr/test/src/testcases/cborattr_decode_simple.c
+++ b/cborattr/test/src/testcases/cborattr_decode_simple.c
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_data(void)
+{
+    CborEncoder test_data;
+    uint8_t data[4] = { 0, 1, 2 };
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &test_data, CborIndefiniteLength);
+    /*
+     * a:22
+     */
+    cbor_encode_text_stringz(&test_data, "a");
+    cbor_encode_uint(&test_data, 22);
+
+    /*
+     * b:-13
+     */
+    cbor_encode_text_stringz(&test_data, "b");
+    cbor_encode_int(&test_data, -13);
+
+    /*
+     * c:0x000102
+     */
+    cbor_encode_text_stringz(&test_data, "c");
+    cbor_encode_byte_string(&test_data, data, 3);
+    cbor_encoder_close_container(&test_encoder, &test_data);
+
+    /*
+     * XXX add other data types to encode here.
+     */
+
+}
+
+/*
+ * Simple decoding.
+ */
+TEST_CASE(test_cborattr_decode_simple)
+{
+    int rc;
+    uint64_t a_val = 0;
+    int64_t b_val = 0;
+    uint8_t c_data[4];
+    size_t c_len;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrIntegerType,
+            .addr.uinteger = &a_val,
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "b",
+            .type = CborAttrIntegerType,
+            .addr.integer = &b_val,
+            .nodefault = true
+        },
+        [2] = {
+            .attribute = "c",
+            .type = CborAttrByteStringType,
+            .addr.bytestring.data = c_data,
+            .addr.bytestring.len = &c_len,
+            .len = sizeof(c_data)
+        },
+        [3] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_data();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(a_val == 22);
+    TEST_ASSERT(b_val == -13);
+    TEST_ASSERT(c_len == 3);
+    TEST_ASSERT(c_data[0] == 0 && c_data[1] == 1 && c_data[2] == 2);
+}

--- a/cborattr/test/src/testcases/cborattr_decode_string_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_string_array.c
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_string_array_one(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+
+    test_cbor_len = 0;
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: ["asdf"]
+     */
+    cbor_encode_text_stringz(&data, "a");
+
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+    cbor_encode_text_stringz(&array, "asdf");
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+static void
+test_encode_string_array_three(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+
+    test_cbor_len = 0;
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * a: ["asdf", "k", "blurb"]
+     */
+    cbor_encode_text_stringz(&data, "a");
+
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+    cbor_encode_text_stringz(&array, "asdf");
+    cbor_encode_text_stringz(&array, "k");
+    cbor_encode_text_stringz(&array, "blurb");
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * string array
+ */
+TEST_CASE(test_cborattr_decode_string_array)
+{
+    int rc;
+    char *str_ptrs[5];
+    char arr_data[256];
+    int arr_cnt = 0;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "a",
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrTextStringType,
+            .addr.array.arr.strings.ptrs = str_ptrs,
+            .addr.array.arr.strings.store = arr_data,
+            .addr.array.arr.strings.storelen = sizeof(arr_data),
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_string_array_one();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 1);
+    TEST_ASSERT(!strcmp(str_ptrs[0], "asdf"));
+
+    test_encode_string_array_three();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 3);
+    TEST_ASSERT(!strcmp(str_ptrs[0], "asdf"));
+    TEST_ASSERT(!strcmp(str_ptrs[1], "k"));
+    TEST_ASSERT(!strcmp(str_ptrs[2], "blurb"));
+}

--- a/cborattr/test/src/testcases/cborattr_decode_substring_key.c
+++ b/cborattr/test/src/testcases/cborattr_decode_substring_key.c
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_substring_key(void)
+{
+    CborEncoder data;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    /*
+     * { "a": "A", "aa": "AA", "aaa" : "AAA" }
+     */
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    cbor_encode_text_stringz(&data, "a");
+    cbor_encode_text_stringz(&data, "A");
+    cbor_encode_text_stringz(&data, "aa");
+    cbor_encode_text_stringz(&data, "AA");
+    cbor_encode_text_stringz(&data, "aaa");
+    cbor_encode_text_stringz(&data, "AAA");
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * substring key
+ */
+TEST_CASE(test_cborattr_decode_substring_key)
+{
+    int rc;
+    char test_str_1a[4] = { '\0' };
+    char test_str_2a[4] = { '\0' };
+    char test_str_3a[4] = { '\0' };
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = "aaa",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_3a,
+            .len = sizeof(test_str_3a),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = "aa",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_2a,
+            .len = sizeof(test_str_2a),
+            .nodefault = true
+            },
+        [2] = {
+            .attribute = "a",
+            .type = CborAttrTextStringType,
+            .addr.string = test_str_1a,
+            .len = sizeof(test_str_1a),
+            .nodefault = true
+            },
+        [3] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_substring_key();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(!strcmp(test_str_1a, "A"));
+    TEST_ASSERT(!strcmp(test_str_2a, "AA"));
+    TEST_ASSERT(!strcmp(test_str_3a, "AAA"));
+}

--- a/cborattr/test/src/testcases/cborattr_decode_unnamed_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_unnamed_array.c
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "test_cborattr.h"
+
+/*
+ * Where we collect cbor data.
+ */
+static uint8_t test_cbor_buf[1024];
+static int test_cbor_len;
+
+/*
+ * CBOR encoder data structures.
+ */
+static int test_cbor_wr(struct cbor_encoder_writer *, const char *, int);
+static CborEncoder test_encoder;
+static struct cbor_encoder_writer test_writer = {
+    .write = test_cbor_wr
+};
+
+static int
+test_cbor_wr(struct cbor_encoder_writer *cew, const char *data, int len)
+{
+    memcpy(test_cbor_buf + test_cbor_len, data, len);
+    test_cbor_len += len;
+
+    assert(test_cbor_len < sizeof(test_cbor_buf));
+    return 0;
+}
+
+static void
+test_encode_unnamed_array(void)
+{
+    CborEncoder data;
+    CborEncoder array;
+
+    cbor_encoder_init(&test_encoder, &test_writer, 0);
+
+    cbor_encoder_create_map(&test_encoder, &data, CborIndefiniteLength);
+
+    /*
+     * [1,2,33]
+     */
+    cbor_encoder_create_array(&data, &array, CborIndefiniteLength);
+    cbor_encode_int(&array, 1);
+    cbor_encode_int(&array, 2);
+    cbor_encode_int(&array, 33);
+    cbor_encoder_close_container(&data, &array);
+
+    cbor_encoder_close_container(&test_encoder, &data);
+}
+
+/*
+ * integer array
+ */
+TEST_CASE(test_cborattr_decode_unnamed_array)
+{
+    int rc;
+    int64_t arr_data[5];
+    int arr_cnt = 0;
+    struct cbor_attr_t test_attrs[] = {
+        [0] = {
+            .attribute = CBORATTR_ATTR_UNNAMED,
+            .type = CborAttrArrayType,
+            .addr.array.element_type = CborAttrIntegerType,
+            .addr.array.arr.integers.store = arr_data,
+            .addr.array.count = &arr_cnt,
+            .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
+            .nodefault = true
+        },
+        [1] = {
+            .attribute = NULL
+        }
+    };
+
+    test_encode_unnamed_array();
+
+    rc = cbor_read_flat_attrs(test_cbor_buf, test_cbor_len, test_attrs);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(arr_cnt == 3);
+    TEST_ASSERT(arr_data[0] == 1);
+    TEST_ASSERT(arr_data[1] == 2);
+    TEST_ASSERT(arr_data[2] == 33);
+}

--- a/cmd/fs_mgmt/pkg.yml
+++ b/cmd/fs_mgmt/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: cmd/fs_mgmt
+pkg.description: 'File system command handlers for mcumgr.'
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-core/fs/fs'

--- a/cmd/fs_mgmt/port/mynewt/src/mynewt_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/mynewt/src/mynewt_fs_mgmt.c
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "mgmt/mgmt.h"
+#include "fs_mgmt/fs_mgmt_impl.h"
+#include "fs/fs.h"
+
+int
+fs_mgmt_impl_filelen(const char *path, size_t *out_len)
+{
+    struct fs_file *file;
+    int rc;
+
+    rc = fs_open(path, FS_ACCESS_READ, &file);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = fs_filelen(file, &out_len);
+    fs_close(file);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}
+
+int
+fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
+                  void *out_data, size_t *out_len)
+{
+    struct fs_file *file;
+    uint32_t bytes_read;
+    int rc;
+
+    rc = fs_open(path, FS_ACCESS_READ, &file);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = fs_seek(file, offset);
+    if (rc != 0) {
+        goto done;
+    }
+
+    rc = fs_read(file, len, file_data, &bytes_read);
+    if (rc != 0) {
+        goto done;
+    }
+
+    *out_len = bytes_read;
+
+done:
+    fs_close(file);
+
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}
+
+int
+fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
+                   size_t len)
+{
+    struct fs_file *file;
+    uint8_t access;
+    int rc;
+ 
+    access = FS_ACCESS_WRITE;
+    if (offset == 0) {
+        access |= FS_ACCESS_TRUNCATE;
+    } else {
+        access |= FS_ACCESS_APPEND;
+    }
+
+    rc = fs_open(path, access, &file);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = fs_write(file, data, len);
+    fs_close(file);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}

--- a/cmd/fs_mgmt/syscfg.yml
+++ b/cmd/fs_mgmt/syscfg.yml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    FS_MGMT_UL_CHUNK_SIZE:
+        description: >
+            Limits the maximum chunk size in file uploads.  A buffer of this
+            size gets allocated on the stack during handling of a file upload
+            command.
+        value: 512
+
+    FS_MGMT_DL_CHUNK_SIZE:
+        description: >
+            Limits the maximum chunk size in file downloads.  A buffer of this
+            size gets allocated on the stack during handling of a file download
+            command.
+        value: 512
+
+    FS_MGMT_PATH_SIZE:
+        description: >
+            Limits the maximum path length in file operations.  A buffer of
+            this size gets allocated on the stack during handling of file
+            upload and download commands.
+        value: 64

--- a/cmd/img_mgmt/pkg.yml
+++ b/cmd/img_mgmt/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: cmd/img_mgmt
+pkg.description: 'Image management command handlers for mcumgr.'
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-core/boot/split'
+    - '@apache-mynewt-core/encoding/base64'
+    - '@apache-mynewt-core/sys/flash_map'
+    - '@mynewt-mcumgr/mgmt'

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sysinit/sysinit.h"
+#include "mgmt/mgmt.h"
+#include "img_mgmt/img_mgmt_impl.h"
+#include "img_mgmt/img_mgmt.h"
+#include "img_mgmt_priv.h"
+
+int
+img_mgmt_impl_erase_slot(void)
+{
+    const struct flash_area *fa;
+    bool empty;
+    int rc;
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_1, &fa);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = flash_area_is_empty(fa, &empty);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    if (!empty) {
+        rc = flash_area_erase(fa, 0, fa->fa_size);
+        if (rc != 0) {
+            return MGMT_ERR_EUNKNOWN;
+        }
+    }
+
+    return 0;
+}
+
+int
+img_mgmt_impl_write_pending(int slot, bool permanent)
+{
+    uint32_t image_flags;
+    uint8_t state_flags;
+    int split_app_active;
+    int rc;
+
+    state_flags = imgmgr_state_flags(slot);
+    split_app_active = split_app_active_get();
+
+    /* Unconfirmed slots are always runable.  A confirmed slot can only be
+     * run if it is a loader in a split image setup.
+     */
+    if (state_flags & IMGMGR_STATE_F_CONFIRMED &&
+        (slot != 0 || !split_app_active)) {
+
+        return MGMT_ERR_EBADSTATE;
+    }
+
+    rc = imgr_read_info(slot, NULL, NULL, &image_flags);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    if (!(image_flags & IMAGE_F_NON_BOOTABLE)) {
+        /* Unified image or loader. */
+        if (!split_app_active) {
+            /* No change in split status. */
+            rc = boot_set_pending(permanent);
+            if (rc != 0) {
+                return MGMT_ERR_EUNKNOWN;
+            }
+        } else {
+            /* Currently loader + app; testing loader-only. */
+            if (permanent) {
+                rc = split_write_split(SPLIT_MODE_LOADER);
+            } else {
+                rc = split_write_split(SPLIT_MODE_TEST_LOADER);
+            }
+            if (rc != 0) {
+                return MGMT_ERR_EUNKNOWN;
+            }
+        }
+    } else {
+        /* Testing split app. */
+        if (permanent) {
+            rc = split_write_split(SPLIT_MODE_APP);
+        } else {
+            rc = split_write_split(SPLIT_MODE_TEST_APP);
+        }
+        if (rc != 0) {
+            return MGMT_ERR_EUNKNOWN;
+        }
+    }
+
+    return 0;
+}
+
+int
+img_mgmt_impl_write_confirmed(void)
+{
+    /* Confirm the unified image or loader in slot 0. */
+    rc = boot_set_confirmed();
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    /* If a split app in slot 1 is active, confirm it as well. */
+    if (split_app_active_get()) {
+        rc = split_write_split(SPLIT_MODE_APP);
+        if (rc != 0) {
+            return MGMT_ERR_EUNKNOWN;
+        }
+    } else {
+        rc = split_write_split(SPLIT_MODE_LOADER);
+        if (rc != 0) {
+            return MGMT_ERR_EUNKNOWN;
+        }
+    }
+
+    return 0;
+}
+
+int
+img_mgmt_impl_read(int slot, unsigned int offset, void *dst,
+                   unsigned int num_bytes)
+{
+    const struct flash_area *fa;
+    int area_id;
+    int rc;
+
+    area_id = flash_area_id_from_image_slot(image_slot);
+    rc = flash_area_open(area_id, &fa);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = flash_area_read(fa, offset, dst, num_bytes);
+    flash_area_close(fa);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}
+
+int
+img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
+                               unsigned int num_bytes, bool last)
+{
+    const struct flash_area *fa;
+    int rc;
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_1, &fa);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = flash_area_write(fa, offset, data, num_bytes);
+    flash_area_close(fa);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}
+
+int
+img_mgmt_impl_swap_type(void)
+{
+    switch (boot_swap_type()) {
+    case BOOT_SWAP_TYPE_NONE:
+        return IMG_MGMT_SWAP_TYPE_NONE;
+    case BOOT_SWAP_TYPE_TEST:
+        return IMG_MGMT_SWAP_TYPE_TEST;
+    case BOOT_SWAP_TYPE_PERM:
+        return IMG_MGMT_SWAP_TYPE_PERM;
+    case BOOT_SWAP_TYPE_REVERT:
+        return IMG_MGMT_SWAP_TYPE_REVERT;
+    default:
+        assert(0);
+        return IMG_MGMT_SWAP_TYPE_NONE;
+    }
+}
+
+void
+img_mgmt_module_init(void)
+{
+    int rc;
+
+    /* Ensure this function only gets called by sysinit. */
+    SYSINIT_ASSERT_ACTIVE();
+
+    rc = img_mgmt_register_group();
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
+#if MYNEWT_VAL(IMGMGR_CLI)
+    rc = imgr_cli_register();
+    SYSINIT_PANIC_ASSERT(rc == 0);
+#endif
+}

--- a/cmd/img_mgmt/syscfg.yml
+++ b/cmd/img_mgmt/syscfg.yml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    IMG_MGMT_UL_CHUNK_SIZE:
+        description: >
+            Limits the maximum chunk size in image uploads.  A buffer of this
+            size gets allocated on the stack during handling of a image upload
+            command.
+        value: 512
+
+    OS_MGMT_TASKSTAT:
+        description: >
+            Enable support for taskstat command.
+        value: 1
+
+    OS_MGMT_ECHO:
+        description: >
+            Enable support for echo command.
+        value: 1

--- a/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
+++ b/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "log/log.h"
+#include "mgmt/mgmt.h"
+#include "log_mgmt/log_mgmt.h"
+#include "log_mgmt/log_mgmt_impl.h"
+#include "../../../src/log_mgmt_config.h"
+
+struct mynewt_log_mgmt_walk_arg {
+    log_mgmt_foreach_entry_fn *cb;
+    uint8_t body[LOG_MGMT_BODY_LEN];
+    void *arg;
+};
+
+static struct log *
+mynewt_log_mgmt_find_log(const char *log_name)
+{
+    struct log *log;
+
+    log = NULL;
+    while (1) {
+        log = log_list_get_next(log);
+        if (log == NULL) {
+            return NULL;
+        }
+
+        if (strcmp(log->l_name, log_name) == 0) {
+            return log;
+        }
+    }
+}
+
+int
+log_mgmt_impl_get_log(int idx, struct log_mgmt_log *out_log)
+{
+    struct log *log;
+    int i;
+
+    log = NULL;
+    for (i = 0; i <= idx; i++) {
+        log = log_list_get_next(log);
+        if (log == NULL) {
+            return MGMT_ERR_ENOENT;
+        }
+    }
+
+    out_log->name = log->l_name;
+    out_log->type = log->l_handler->type;
+    return 0;
+}
+
+int
+log_mgmt_impl_get_module(int idx, const char **out_module_name)
+{
+    const char *name;
+
+    name = LOG_MODULE_STR(idx);
+    if (name == NULL) {
+        return MGMT_ERR_ENOENT;
+    } else {
+        *out_module_name = name;
+        return 0;
+    }
+}
+
+int
+log_mgmt_impl_get_level(int idx, const char **out_level_name)
+{
+    const char *name;
+
+    name = LOG_LEVEL_STR(idx);
+    if (name == NULL) {
+        return MGMT_ERR_ENOENT;
+    } else {
+        *out_level_name = name;
+        return 0;
+    }
+}
+
+int
+log_mgmt_impl_get_next_idx(uint32_t *out_idx)
+{
+    *out_idx = g_log_info.li_next_index;
+    return 0;
+}
+
+static int
+mynewt_log_mgmt_walk_cb(struct log *log, struct log_offset *log_offset,
+                        const void *desciptor, uint16_t len)
+{
+    struct mynewt_log_mgmt_walk_arg *mynewt_log_mgmt_walk_arg;
+    struct log_mgmt_entry entry;
+    struct log_entry_hdr ueh;
+    int read_len;
+    int rc;
+
+    mynewt_log_mgmt_walk_arg = log_offset->lo_arg;
+
+    rc = log_read(log, desciptor, &ueh, 0, sizeof ueh);
+    if (rc != sizeof ueh) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    /* If specified timestamp is nonzero, it is the primary criterion, and the
+     * specified index is the secondary criterion.  If specified timetsamp is
+     * zero, specified index is the only criterion.
+     *
+     * If specified timestamp == 0: encode entries whose index >=
+     *     specified index.
+     * Else: encode entries whose timestamp >= specified timestamp and whose
+     *      index >= specified index
+     */
+
+    if (log_offset->lo_ts == 0) {
+        if (log_offset->lo_index > ueh.ue_index) {
+            return 0;
+        }
+    } else if (ueh.ue_ts < log_offset->lo_ts   ||
+               (ueh.ue_ts == log_offset->lo_ts &&
+                ueh.ue_index < log_offset->lo_index)) {
+        return 0;
+    }
+
+    read_len = min(len - sizeof ueh, LOG_MGMT_BODY_LEN - sizeof ueh);
+    rc = log_read(log, desciptor, mynewt_log_mgmt_walk_arg->body, sizeof ueh,
+                  read_len);
+    if (rc < 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    entry.ts = ueh.ue_ts;
+    entry.index = ueh.ue_index;
+    entry.module = ueh.ue_module;
+    entry.level = ueh.ue_level;
+    entry.len = rc;
+    entry.data = mynewt_log_mgmt_walk_arg->body;
+
+    return mynewt_log_mgmt_walk_arg->cb(&entry, mynewt_log_mgmt_walk_arg->arg);
+}
+
+int
+log_mgmt_impl_foreach_entry(const char *log_name,
+                            const struct log_mgmt_filter *filter,
+                            log_mgmt_foreach_entry_fn *cb, void *arg)
+{
+    struct mynewt_log_mgmt_walk_arg walk_arg;
+    struct log_offset offset;
+    struct log *log;
+
+    walk_arg = (struct mynewt_log_mgmt_walk_arg) {
+        .cb = cb,
+        .arg = arg,
+    };
+
+    log = mynewt_log_mgmt_find_log(log_name);
+    if (log == NULL) {
+        return MGMT_ERR_ENOENT;
+    }
+
+    if (strcmp(log->l_name, log_name) == 0) {
+        offset.lo_arg = &walk_arg;
+        offset.lo_ts = filter->min_timestamp;
+        offset.lo_index = filter->min_index;
+        offset.lo_data_len = 0;
+
+        return log_walk(log, mynewt_log_mgmt_walk_cb, &offset);
+    }
+
+    return MGMT_ERR_ENOENT;
+}
+
+int
+log_mgmt_impl_clear(const char *log_name)
+{
+    struct log *log;
+    int rc;
+
+    log = mynewt_log_mgmt_find_log(log_name);
+    if (log == NULL) {
+        return MGMT_ERR_ENOENT;
+    }
+
+    rc = log_flush(log);
+    if (rc != 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
+
+    return 0;
+}

--- a/cmd/os_mgmt/pkg.yml
+++ b/cmd/os_mgmt/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: cmd/os_mgmt
+pkg.description: 'OS management command handlers for mcumgr.'
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-core/kernel/os'

--- a/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
+++ b/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "hal/hal_system.h"
+#include "hal/hal_watchdog.h"
+#include "os/os.h"
+#if MYNEWT_VAL(LOG_SOFT_RESET)
+#include "reboot/log_reboot.h"
+#endif
+#include "os_mgmt/os_mgmt_impl.h"
+
+static struct os_callout mynewt_os_mgmt_reset_callout;
+
+static void
+mynewt_os_mgmt_reset_tmo(struct os_event *ev)
+{
+    /* Tickle watchdog just before re-entering bootloader.  Depending on what
+     * the system has been doing lately, the watchdog timer might be close to
+     * firing.
+     */
+    hal_watchdog_tickle();
+    hal_system_reset();
+}
+
+static uint16_t
+mynewt_os_mgmt_stack_usage(const struct os_task *task)
+{
+    const os_stack_t *bottom;
+    const os_stack_t *top;
+
+    top = task->t_stacktop;
+    bottom = task->t_stacktop - task->t_stacksize;
+    while (bottom < top) {
+        if (*bottom != OS_STACK_PATTERN) {
+            break;
+        }
+        ++bottom;
+    }
+
+    return task->t_stacktop - bottom;
+}
+
+static const struct os_task *
+mynewt_os_mgmt_task_at(int idx)
+{
+    const struct os_task *task;
+    int i;
+
+    task = STAILQ_FIRST(&g_os_task_list);
+    for (i = 0; i < idx; i++) {
+        if (task == NULL) {
+            break;
+        }
+
+        task = STAILQ_NEXT(task, t_os_task_list);
+    }
+
+    return task;
+}
+
+int
+os_mgmt_impl_task_info(int idx, struct os_mgmt_task_info *out_info)
+{
+    const struct os_task *task;
+
+    task = mynewt_os_mgmt_task_at(idx);
+    if (task == NULL) {
+        return MGMT_ERR_ENOENT;
+    }
+
+    out_info->oti_prio = task->t_prio;
+    out_info->oti_taskid = task->t_taskid;
+    out_info->oti_state = task->t_state;
+    out_info->oti_stkusage = mynewt_os_mgmt_stack_usage(task);
+    out_info->oti_stksize = task->t_stacksize;
+    out_info->oti_cswcnt = task->t_ctx_sw_cnt;
+    out_info->oti_runtime = task->t_run_time;
+    out_info->oti_last_checkin = task->t_sanity_check.sc_checkin_last;
+    out_info->oti_next_checkin = task->t_sanity_check.sc_checkin_last +
+                                 task->t_sanity_check.sc_checkin_itvl;
+    strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name);
+
+    return 0;
+}
+
+int
+os_mgmt_impl_reset(unsigned int delay_ms)
+{
+    int rc;
+
+    os_callout_init(&mynewt_os_mgmt_reset_callout, mgmt_evq_get(),
+                    nmgr_reset_tmo, NULL);
+
+#if MYNEWT_VAL(LOG_SOFT_RESET)
+    log_reboot(HAL_RESET_REQUESTED);
+#endif
+    os_callout_reset(&nmgr_reset_callout, delay_ms * OS_TICKS_PER_SEC / 1000);
+
+    return 0;
+}

--- a/cmd/os_mgmt/syscfg.yml
+++ b/cmd/os_mgmt/syscfg.yml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    OS_MGMT_RESET_MS:
+        description: >
+            When a reset command is received, the system waits this many
+            milliseconds before performing the reset.  This delay allows time
+            for the mcumgr response to be delivered.
+        value: 250

--- a/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/include/mgmt/mgmt.h
@@ -64,6 +64,13 @@ extern "C" {
 
 #define MGMT_HDR_SIZE           8
 
+/*
+ * MGMT event opcodes.
+ */
+#define MGMT_EVT_OP_CMD_RECV            0x01
+#define MGMT_EVT_OP_CMD_STATUS          0x02
+#define MGMT_EVT_OP_CMD_DONE            0x03
+
 struct mgmt_hdr {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t  nh_op:3;           /* MGMT_OP_[...] */
@@ -79,6 +86,33 @@ struct mgmt_hdr {
     uint8_t  nh_seq;            /* Sequence number */
     uint8_t  nh_id;             /* Message ID within group */
 };
+
+/*
+ * MGMT_EVT_OP_CMD_STATUS argument
+ */
+struct mgmt_evt_op_cmd_status_arg {
+    int status;
+};
+
+/*
+ * MGMT_EVT_OP_CMD_DONE argument
+ */
+struct mgmt_evt_op_cmd_done_arg {
+    int err;                    /* MGMT_ERR_[...] */
+};
+
+/** @typedef mgmt_on_evt_cb
+ * @brief Function to be called on MGMT event.
+ *
+ * This callback function is used to notify application about mgmt event.
+ *
+ * @param opcode                MGMT_EVT_OP_[...].
+ * @param group                 MGMT_GROUP_ID_[...].
+ * @param id                    Message ID within group.
+ * @param arg                   Optional event argument.
+ */
+typedef void mgmt_on_evt_cb(uint8_t opcode, uint16_t group, uint8_t id,
+                            void *arg);
 
 /** @typedef mgmt_alloc_rsp_fn
  * @brief Allocates a buffer suitable for holding a response.
@@ -380,6 +414,23 @@ void mgmt_ntoh_hdr(struct mgmt_hdr *hdr);
  * @param hdr                   The mcumgr header to byte-swap.
  */
 void mgmt_hton_hdr(struct mgmt_hdr *hdr);
+
+/**
+ * @brief Register event callback function.
+ *
+ * @param cb                    Callback function.
+ */
+void mgmt_register_evt_cb(mgmt_on_evt_cb *cb);
+
+/**
+ * @brief This function is called to notify about mgmt event.
+ *
+ * @param opcode                MGMT_EVT_OP_[...].
+ * @param group                 MGMT_GROUP_ID_[...].
+ * @param id                    Message ID within group.
+ * @param arg                   Optional event argument.
+ */
+void mgmt_evt(uint8_t opcode, uint16_t group, uint8_t id, void *arg);
 
 #ifdef __cplusplus
 }

--- a/mgmt/pkg.yml
+++ b/mgmt/pkg.yml
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: mgmt
+pkg.description: 'System-wide mcumgr management interfaces.'
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-core/encoding/tinycbor'
+    - '@apache-mynewt-core/kernel/os'
+    - '@mynewt-mcumgr/mgmt'

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -22,6 +22,7 @@
 #include "mgmt/endian.h"
 #include "mgmt/mgmt.h"
 
+static mgmt_on_evt_cb *evt_cb;
 static struct mgmt_group *mgmt_group_list;
 static struct mgmt_group *mgmt_group_list_end;
 
@@ -167,4 +168,18 @@ mgmt_hton_hdr(struct mgmt_hdr *hdr)
 {
     hdr->nh_len = htons(hdr->nh_len);
     hdr->nh_group = htons(hdr->nh_group);
+}
+
+void
+mgmt_register_evt_cb(mgmt_on_evt_cb *cb)
+{
+    evt_cb = cb;
+}
+
+void
+mgmt_evt(uint8_t opcode, uint16_t group, uint8_t id, void *arg)
+{
+    if (evt_cb) {
+        evt_cb(opcode, group, id, arg);
+    }
 }

--- a/mgmt/syscfg.yml
+++ b/mgmt/syscfg.yml
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#

--- a/protocol.md
+++ b/protocol.md
@@ -1,0 +1,244 @@
+# SMP (Simple Management Protocol) Protocol Notes
+
+The `mcumgr` SMP server and `mcumgr-cli` SMP client tool ([source](https://github.com/apache/mynewt-mcumgr-cli))
+use a custom protocol to send commands and responses between the server and client using a
+variety of transports (currently TTY serial or BLE).
+
+The protocol isn't fully documented but the following information has been inferred
+from the source code available on Github and using the `-l DEBUG` flag when
+executing commands.
+
+## Source Code
+
+**SMP** is based on the earlier **NMP**, which is part of [Apache Mynewt](https://mynewt.apache.org/).
+
+The golang source for the original **newtmgr** is [available here](https://github.com/apache/mynewt-newtmgr),
+and can be used to provide some insight into how data is exchanged between the
+utility and the device under test.
+
+This repository (`mynewt-mcumgr`) implements an SMP server in **C**,
+and a new command-line SMP client called **mcumgr** was created at 
+[apache/mynewt-mcumgr-cli](https://github.com/apache/mynewt-mcumgr-cli).
+
+## SMP Frame Format
+
+### Endianness
+
+Frames are normally serialized as **Big Endian** when dealing with values > 8 bits. This is
+mandatory in NMP, but the SMP implementation does add support for **Little Endian** as an
+option at the struct level, as shown below.
+
+### Frame Header
+
+Frames in SMP have the following header format:
+
+```
+struct mgmt_hdr {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    uint8_t  nh_op:3;           /* MGMT_OP_[...] */
+    uint8_t  _res1:5;
+#endif
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    uint8_t  _res1:5;
+    uint8_t  nh_op:3;           /* MGMT_OP_[...] */
+#endif
+    uint8_t  nh_flags;          /* Reserved for future flags */
+    uint16_t nh_len;            /* Length of the payload */
+    uint16_t nh_group;          /* MGMT_GROUP_ID_[...] */
+    uint8_t  nh_seq;            /* Sequence number */
+    uint8_t  nh_id;             /* Message ID within group */
+};
+```
+
+The NMP/newtmgr [go source](https://github.com/apache/mynewt-newtmgr/blob/master/nmxact/nmp/nmp.go) is as follows,
+without the option to select endianness:
+
+```
+type NmpHdr struct {
+	Op    uint8 /* 3 bits of opcode */
+	Flags uint8
+	Len   uint16
+	Group uint16
+	Seq   uint8
+	Id    uint8
+}
+```
+
+`nh_op` (or `Op` in newtmgr) can be one of the following values:
+
+```
+/** Opcodes; encoded in first byte of header. */
+#define MGMT_OP_READ            0
+#define MGMT_OP_READ_RSP        1
+#define MGMT_OP_WRITE           2
+#define MGMT_OP_WRITE_RSP       3
+```
+
+- **`op`**: The operation code
+- **`Flags`**: TBD
+- **`Len`**:  The payload len when `Data` is present
+- **`Group`**: Commands are organized into groups. Groups are defined
+  [here](https://github.com/apache/mynewt-mcumgr/blob/master/mgmt/include/mgmt/mgmt.h).
+- **`Seq`**: TBD
+- **`Id`**: The command ID to send. Commands in the default `Group` are defined
+  [here](https://github.com/apache/mynewt-mcumgr/blob/master/mgmt/include/mgmt/mgmt.h).
+
+#### `Data` Payload
+
+If `nh_len` (`Len` in nmp) is non-zero, the `nh_len` byte payload (referred to as **`Data`** in this document) immediately follows the frame header.
+
+### Example Packets
+
+The following example commands show how the different fields work:
+
+#### Simple Read Request: `taskstats`
+
+The following example corresponds to the `taskstats` command ([source](https://github.com/apache/mynewt-mcumgr/blob/master/cmd/os_mgmt/include/os_mgmt/os_mgmt.h)), and
+can be seen by running `mcumgr -l DEBUG -c serial taskstats`:
+
+```
+Op:    0  # NMGR_OP_READ
+Flags: 0
+Len:   0  # No payload present
+Group: 0  # 0x00 = NMGR_GROUP_ID_DEFAULT
+Seq:   0
+Id:    2  # 0x02 in group 0x00 = OS_MGMT_ID_TASKSTAT
+Data:  [] # No payload (len = 0 above)
+```
+
+When serialized this will be sent as `0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x02`.
+
+If this was sent using the serial port, you would get the following request and response:
+
+```
+$ mcumgr -l DEBUG -c serial taskstats
+2016/11/11 12:45:44 [DEBUG] Writing newtmgr request &{Op:0 Flags:0 Len:0 Group:0 Seq:0 Id:2 Data:[]}
+2016/11/11 12:45:44 [DEBUG] Serializing request &{Op:0 Flags:0 Len:0 Group:0 Seq:0 Id:2 Data:[]} into buffer [0 0 0 0 0 0 0 2]
+2016/11/11 12:45:44 [DEBUG] Tx packet dump:
+00000000  00 00 00 00 00 00 00 02                           |........|
+
+2016/11/11 12:45:44 [DEBUG] Writing [6 9] to data channel
+2016/11/11 12:45:44 [DEBUG] Writing [65 65 111 65 65 65 65 65 65 65 65 65 65 105 66 67] to data channel
+2016/11/11 12:45:44 [DEBUG] Writing [10] to data channel
+2016/11/11 12:45:44 [DEBUG] Reading [6 9 65 65 111 65 65 65 65 65 65 65 65 65 65 105 66 67] from data channel
+2016/11/11 12:45:44 [DEBUG] Rx packet dump:
+00000000  00 00 00 00 00 00 00 02                           |........|
+
+2016/11/11 12:45:44 [DEBUG] Deserialized response &{Op:0 Flags:0 Len:0 Group:0 Seq:0 Id:2 Data:[]}
+2016/11/11 12:45:44 [DEBUG] Reading [13] from data channel
+2016/11/11 12:45:44 [DEBUG] Reading [6 9 65 90 119 66 65 81 71 83 65 65 65 65 65 114 57 105 99 109 77 65 90 88 82 104 99 50 116 122 118 50 82 112 90 71 120 108 118 50 82 119 99 109 108 118 71 80 57 106 100 71 108 107 65 71 86 122 100 71 70 48 90 81 70 109 99 51 82 114 100 88 78 108 71 66 108 109 99 51 82 114 99 50 108 54 71 69 66 109 89 51 78 51 89 50 53 48 71 103 65 85 102 109 112 110 99 110 86 117 100 71 108 116 90 82 111 65 69 53 120 80 98 71 120 104 99 51 82 102] from data channel
+2016/11/11 12:45:44 [DEBUG] Reading [4 20 89 50 104 108 89 50 116 112 98 103 66 115 98 109 86 52 100 70 57 106 97 71 86 106 97 50 108 117 65 80 57 109 89 109 120 108 88 50 120 115 118 50 82 119 99 109 108 118 65 71 78 48 97 87 81 66 90 88 78 48 89 88 82 108 65 109 90 122 100 71 116 49 99 50 85 89 79 109 90 122 100 71 116 122 97 88 111 89 85 71 90 106 99 51 100 106 98 110 81 90 54 112 120 110 99 110 86 117 100 71 108 116 90 82 107 74 82 87 120 115 89 88 78 48 88 50 78 111] from data channel
+2016/11/11 12:45:44 [DEBUG] Reading [4 20 90 87 78 114 97 87 52 65 98 71 53 108 101 72 82 102 89 50 104 108 89 50 116 112 98 103 68 47 98 109 74 115 90 88 86 104 99 110 82 102 89 110 74 112 90 71 100 108 118 50 82 119 99 109 108 118 66 87 78 48 97 87 81 67 90 88 78 48 89 88 82 108 65 87 90 122 100 71 116 49 99 50 85 89 72 50 90 122 100 71 116 122 97 88 111 90 65 81 66 109 89 51 78 51 89 50 53 48 71 103 65 84 113 89 78 110 99 110 86 117 100 71 108 116 90 81 66 115] from data channel
+2016/11/11 12:45:44 [DEBUG] Reading [4 20 98 71 70 122 100 70 57 106 97 71 86 106 97 50 108 117 65 71 120 117 90 88 104 48 88 50 78 111 90 87 78 114 97 87 52 65 47 50 100 105 98 71 86 119 99 110 66 111 118 50 82 119 99 109 108 118 65 87 78 48 97 87 81 68 90 88 78 48 89 88 82 108 65 87 90 122 100 71 116 49 99 50 85 89 48 50 90 122 100 71 116 122 97 88 111 90 65 86 66 109 89 51 78 51 89 50 53 48 71 81 113 68 90 51 74 49 98 110 82 112 98 87 85 69 98 71 120 104] from data channel
+2016/11/11 12:45:44 [DEBUG] Reading [4 20 99 51 82 102 89 50 104 108 89 50 116 112 98 103 66 115 98 109 86 52 100 70 57 106 97 71 86 106 97 50 108 117 65 80 47 47 47 56 85 88] from data channel
+2016/11/11 12:45:44 [DEBUG] Rx packet dump:
+00000000  01 01 01 92 00 00 00 02  bf 62 72 63 00 65 74 61  |.........brc.eta|
+00000010  73 6b 73 bf 64 69 64 6c  65 bf 64 70 72 69 6f 18  |sks.didle.dprio.|
+00000020  ff 63 74 69 64 00 65 73  74 61 74 65 01 66 73 74  |.ctid.estate.fst|
+00000030  6b 75 73 65 18 19 66 73  74 6b 73 69 7a 18 40 66  |kuse..fstksiz.@f|
+00000040  63 73 77 63 6e 74 1a 00  14 7e 6a 67 72 75 6e 74  |cswcnt...~jgrunt|
+00000050  69 6d 65 1a 00 13 9c 4f  6c 6c 61 73 74 5f 63 68  |ime....Ollast_ch|
+00000060  65 63 6b 69 6e 00 6c 6e  65 78 74 5f 63 68 65 63  |eckin.lnext_chec|
+00000070  6b 69 6e 00 ff 66 62 6c  65 5f 6c 6c bf 64 70 72  |kin..fble_ll.dpr|
+00000080  69 6f 00 63 74 69 64 01  65 73 74 61 74 65 02 66  |io.ctid.estate.f|
+00000090  73 74 6b 75 73 65 18 3a  66 73 74 6b 73 69 7a 18  |stkuse.:fstksiz.|
+000000a0  50 66 63 73 77 63 6e 74  19 ea 9c 67 72 75 6e 74  |Pfcswcnt...grunt|
+000000b0  69 6d 65 19 09 45 6c 6c  61 73 74 5f 63 68 65 63  |ime..Ellast_chec|
+000000c0  6b 69 6e 00 6c 6e 65 78  74 5f 63 68 65 63 6b 69  |kin.lnext_checki|
+000000d0  6e 00 ff 6e 62 6c 65 75  61 72 74 5f 62 72 69 64  |n..nbleuart_brid|
+000000e0  67 65 bf 64 70 72 69 6f  05 63 74 69 64 02 65 73  |ge.dprio.ctid.es|
+000000f0  74 61 74 65 01 66 73 74  6b 75 73 65 18 1f 66 73  |tate.fstkuse..fs|
+00000100  74 6b 73 69 7a 19 01 00  66 63 73 77 63 6e 74 1a  |tksiz...fcswcnt.|
+00000110  00 13 a9 83 67 72 75 6e  74 69 6d 65 00 6c 6c 61  |....gruntime.lla|
+00000120  73 74 5f 63 68 65 63 6b  69 6e 00 6c 6e 65 78 74  |st_checkin.lnext|
+00000130  5f 63 68 65 63 6b 69 6e  00 ff 67 62 6c 65 70 72  |_checkin..gblepr|
+00000140  70 68 bf 64 70 72 69 6f  01 63 74 69 64 03 65 73  |ph.dprio.ctid.es|
+00000150  74 61 74 65 01 66 73 74  6b 75 73 65 18 d3 66 73  |tate.fstkuse..fs|
+00000160  74 6b 73 69 7a 19 01 50  66 63 73 77 63 6e 74 19  |tksiz..Pfcswcnt.|
+00000170  0a 83 67 72 75 6e 74 69  6d 65 04 6c 6c 61 73 74  |..gruntime.llast|
+00000180  5f 63 68 65 63 6b 69 6e  00 6c 6e 65 78 74 5f 63  |_checkin.lnext_c|
+00000190  68 65 63 6b 69 6e 00 ff  ff ff                    |heckin....|
+
+2016/11/11 12:45:44 [DEBUG] Deserialized response &{Op:1 Flags:1 Len:402 Group:0 Seq:0 Id:2 Data:[191 98 114 99 0 101 116 97 115 107 115 191 100 105 100 108 101 191 100 112 114 105 111 24 255 99 116 105 100 0 101 115 116 97 116 101 1 102 115 116 107 117 115 101 24 25 102 115 116 107 115 105 122 24 64 102 99 115 119 99 110 116 26 0 20 126 106 103 114 117 110 116 105 109 101 26 0 19 156 79 108 108 97 115 116 95 99 104 101 99 107 105 110 0 108 110 101 120 116 95 99 104 101 99 107 105 110 0 255 102 98 108 101 95 108 108 191 100 112 114 105 111 0 99 116 105 100 1 101 115 116 97 116 101 2 102 115 116 107 117 115 101 24 58 102 115 116 107 115 105 122 24 80 102 99 115 119 99 110 116 25 234 156 103 114 117 110 116 105 109 101 25 9 69 108 108 97 115 116 95 99 104 101 99 107 105 110 0 108 110 101 120 116 95 99 104 101 99 107 105 110 0 255 110 98 108 101 117 97 114 116 95 98 114 105 100 103 101 191 100 112 114 105 111 5 99 116 105 100 2 101 115 116 97 116 101 1 102 115 116 107 117 115 101 24 31 102 115 116 107 115 105 122 25 1 0 102 99 115 119 99 110 116 26 0 19 169 131 103 114 117 110 116 105 109 101 0 108 108 97 115 116 95 99 104 101 99 107 105 110 0 108 110 101 120 116 95 99 104 101 99 107 105 110 0 255 103 98 108 101 112 114 112 104 191 100 112 114 105 111 1 99 116 105 100 3 101 115 116 97 116 101 1 102 115 116 107 117 115 101 24 211 102 115 116 107 115 105 122 25 1 80 102 99 115 119 99 110 116 25 10 131 103 114 117 110 116 105 109 101 4 108 108 97 115 116 95 99 104 101 99 107 105 110 0 108 110 101 120 116 95 99 104 101 99 107 105 110 0 255 255 255]}
+Return Code = 0
+      task pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
+  bleuart_bridge   5   2        0  1288579      256       31        0        0
+   bleprph   1   3        4     2691      336      211        0        0
+      idle 255   0  1285199  1343082       64       25        0        0
+    ble_ll   0   1     2373    60060       80       58        0        0
+```
+
+#### Group Read Request: `image list`
+
+The following command lists images on the device and uses commands from `Group`
+0x01 (`MGMT_GROUP_ID_IMAGE`), and was generated with `$ mcumgr -l DEBUG -c serial image list`:
+
+> See [img_mgmt](https://github.com/apache/mynewt-mcumgr/tree/master/cmd/img_mgmt)
+for a full list of commands in the IMAGE `Group`.
+
+```
+$ mcumgr -l DEBUG -c serial image list
+2016/11/11 12:25:51 [DEBUG] Writing newtmgr request &{Op:0 Flags:0 Len:0 Group:1 Seq:0 Id:0 Data:[]}
+2016/11/11 12:25:51 [DEBUG] Serializing request &{Op:0 Flags:0 Len:0 Group:1 Seq:0 Id:0 Data:[]} into buffer [0 0 0 0 0 1 0 0]
+2016/11/11 12:25:51 [DEBUG] Tx packet dump:
+00000000  00 00 00 00 00 01 00 00                           |........|
+
+2016/11/11 12:25:51 [DEBUG] Writing [6 9] to data channel
+2016/11/11 12:25:51 [DEBUG] Writing [65 65 111 65 65 65 65 65 65 65 69 65 65 68 99 119] to data channel
+2016/11/11 12:25:51 [DEBUG] Writing [10] to data channel
+2016/11/11 12:25:51 [DEBUG] Reading [6 9 65 65 111 65 65 65 65 65 65 65 69 65 65 68 99 119] from data channel
+2016/11/11 12:25:51 [DEBUG] Rx packet dump:
+00000000  00 00 00 00 00 01 00 00                           |........|
+
+2016/11/11 12:25:51 [DEBUG] Deserialized response &{Op:0 Flags:0 Len:0 Group:1 Seq:0 Id:0 Data:[]}
+2016/11/11 12:25:51 [DEBUG] Reading [13] from data channel
+2016/11/11 12:25:51 [DEBUG] Reading [6 9 65 73 85 66 65 81 66 55 65 65 69 65 65 76 57 109 97 87 49 104 90 50 86 122 110 55 57 107 99 50 120 118 100 65 66 110 100 109 86 121 99 50 108 118 98 109 85 119 76 106 77 117 77 71 82 111 89 88 78 111 87 67 68 83 84 76 77 70 69 49 81 88 75 55 85 81 110 53 121 48 114 110 104 104 50 87 49 113 47 102 120 71 50 48 103 115 54 121 48 48 113 75 101 79 48 71 104 105 98 50 57 48 89 87 74 115 90 102 86 110 99 71 86 117 90 71 108 117] from data channel
+2016/11/11 12:25:51 [DEBUG] Reading [4 20 90 47 82 112 89 50 57 117 90 109 108 121 98 87 86 107 57 87 90 104 89 51 82 112 100 109 88 49 47 47 57 114 99 51 66 115 97 88 82 84 100 71 70 48 100 88 77 65 47 49 78 116] from data channel
+2016/11/11 12:25:51 [DEBUG] Rx packet dump:
+00000000  01 01 00 7b 00 01 00 00  bf 66 69 6d 61 67 65 73  |...{.....fimages|
+00000010  9f bf 64 73 6c 6f 74 00  67 76 65 72 73 69 6f 6e  |..dslot.gversion|
+00000020  65 30 2e 33 2e 30 64 68  61 73 68 58 20 d2 4c b3  |e0.3.0dhashX .L.|
+00000030  05 13 54 17 2b b5 10 9f  9c b4 ae 78 61 d9 6d 6a  |..T.+......xa.mj|
+00000040  fd fc 46 db 48 2c eb 2d  34 a8 a7 8e d0 68 62 6f  |..F.H,.-4....hbo|
+00000050  6f 74 61 62 6c 65 f5 67  70 65 6e 64 69 6e 67 f4  |otable.gpending.|
+00000060  69 63 6f 6e 66 69 72 6d  65 64 f5 66 61 63 74 69  |iconfirmed.facti|
+00000070  76 65 f5 ff ff 6b 73 70  6c 69 74 53 74 61 74 75  |ve...ksplitStatu|
+00000080  73 00 ff                                          |s..|
+
+2016/11/11 12:25:51 [DEBUG] Deserialized response &{Op:1 Flags:1 Len:123 Group:1 Seq:0 Id:0 Data:[191 102 105 109 97 103 101 115 159 191 100 115 108 111 116 0 103 118 101 114 115 105 111 110 101 48 46 51 46 48 100 104 97 115 104 88 32 210 76 179 5 19 84 23 43 181 16 159 156 180 174 120 97 217 109 106 253 252 70 219 72 44 235 45 52 168 167 142 208 104 98 111 111 116 97 98 108 101 245 103 112 101 110 100 105 110 103 244 105 99 111 110 102 105 114 109 101 100 245 102 97 99 116 105 118 101 245 255 255 107 115 112 108 105 116 83 116 97 116 117 115 0 255]}
+Images:
+ slot=0
+    version: 0.3.0
+    bootable: true
+    flags: active confirmed
+    hash: d24cb3051354172bb5109f9cb4ae7861d96d6afdfc46db482ceb2d34a8a78ed0
+Split status: N/A
+```
+
+When serialised this will be sent as `0x00 0x00 0x00 0x00 0x00 0x01 0x00 0x00`.
+
+## Transports
+
+### Mcumgr/Newtmgr SMP Client Over Serial
+
+`mcumgr` or `newtmgr` can be used over TTY serial with the following parameters
+to connect to a SMP server running on the target device:
+
+- Baud Rate: 115200
+- HW Flow Control: None
+
+### Mcumgr/Newtmgr SMP Client Over BLE
+
+`mcumgr` or `newtmgr` can be used over BLE with the following GATT service and
+characteristic UUIDs to connect to a SMP server running on the target device:
+
+- **Service UUID**: `8D53DC1D-1DB7-4CD3-868B-8A527460AA84`
+- **Characteristic UUID**: `DA2E7828-FBCE-4E01-AE9E-261174997C48`
+
+The  "SMP" GATT service consists of one **write no-rsp characteristic**
+for SMP requests: a single-byte characteristic that
+can only accepts write-without-response commands. The contents of
+each write command contains an SMP request.
+
+SMP responses are sent back in the form of unsolicited notifications
+from the same characteristic.

--- a/repository.yml
+++ b/repository.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+repo.name: mynewt-mcumgr
+repo.versions:
+    "0.0.0": "master"
+
+    "0-latest": "0.0.0"
+    "0-dev": "0.0.0"

--- a/samples/smp_svr/README.md
+++ b/samples/smp_svr/README.md
@@ -1,0 +1,139 @@
+# smp_svr
+
+This sample application implements a simple SMP server with the following
+transports:
+    * Shell
+    * Bluetooth
+
+`smp_svr` enables support for the following command groups:
+    * fs_mgmt
+    * img_mgmt
+    * log_mgmt (Mynewt only)
+    * os_mgmt
+    * stat_mgmt
+
+## Mynewt
+
+The Mynewt port of `smp_svr` is a regular Mynewt app.  The below example uses the nRF52dk as the BSP, so you may need to adjust accordingly if you are using different hardware.
+
+0. Create a Mynewt project and upload the Apache mynewt boot loader to your
+board as described here: http://mynewt.apache.org/latest/os/tutorials/nRF52/
+
+1. Add the mcumgr repo to your `project.yml` file:
+
+```
+repository.mynewt-mcumgr:
+    type: git
+    vers: 0-latest
+    url: 'git@github.com:apache/mynewt-mcumgr.git'
+```
+
+2. Create a target that ties the `smp_svr` app to your BSP of choice (nRF52dk in this example):
+
+```
+$ newt target create smp_svr-nrf52dk
+$ newt target set smp_svr-nrf52dk app=@mynewt-mcumgr/samples/smp_svr/apache \
+                                  bsp=@apache-mynewt-core/hw/bsp/nrf52dk    \
+                                  build_profile=debug
+```
+
+3. Build, upload, and run the application on your board:
+
+```
+$ newt run smp_svr-nrf52dk
+```
+
+## Zephyr
+
+The Zephyr port of `smp_svr` is configured to run on an nRF52 MCU.  The
+application should build and run for other platforms without modification, but
+the file system management commands will not work.  To enable file system
+management for a different platform, adjust the `CONFIG_FS_NFFS_FLASH_DEV_NAME`
+setting in `prj.conf` accordingly.
+
+In addition, the MCUboot boot loader (https://github.com/runtimeco/mcuboot) is
+required for img_mgmt to function properly.
+
+### Building
+
+The below steps describe how to build and run the `smp_svr` sample app in
+Zephyr.  Where examples are given, they assume the following setup:
+
+* BSP: Nordic nRF52dk
+* MCU: PCA10040
+
+If you would like to use a more constrained platform, such as the nRF51, you
+should use the `prj.conf.tiny` configuration file rather than the default
+`prj.conf`.
+
+#### Step 1: Configure environment
+
+Define the `BOARD`, `ZEPHYR_TOOLCHAIN_VARIANT`, and any other environment
+variables required by your setup.  For our example, we use the following:
+
+```
+export ZEPHYR_TOOLCHAIN_VARIANT=gccarmemb
+export BOARD=nrf52_pca10040
+export GCCARMEMB_TOOLCHAIN_PATH=/usr/local/Caskroom/gcc-arm-embedded/6-2017-q2-update/gcc-arm-none-eabi-6-2017-q2-update
+```
+
+#### Step 2: Build MCUboot
+
+Build MCUboot by following the instructions in its `docs/readme-zephyr.md`
+file.
+
+#### Step 3: Upload MCUboot
+
+Upload the resulting `zephyr.bin` file to address 0 of your board.  This can be
+done in gdb as follows:
+
+```
+restore <path-to-mcuboot-zephyr.bin> binary 0
+```
+
+#### Step 4: Build smp_svr
+
+The Zephyr port of `smp_svr` can be built using the usual procedure:
+
+```
+$ cd samples/smp_svr/zephyr
+$ mkdir build && cd build
+$ cmake ..
+$ make
+```
+
+#### Step 5: Create an MCUboot-compatible image
+
+Using MCUboot's `imgtool.py` script, convert the `zephyr.bin` file from step 4
+into an image file.  In the below example, the MCUboot repo is located at `~/repos/mcuboot`.
+
+```
+~/repos/mcuboot/scripts/imgtool.py sign \
+    --header-size 0x200 \
+    --align 8 \
+    --version 1.0 \
+    --included-header \
+    --key ~/repos/mcuboot/root-rsa-2048.pem \
+    <path-to-smp_svr-zephyr.bin> signed.img
+```
+
+The above command creates an image file called `signed.img` in the current
+directory.
+
+#### Step 6: Upload the smp_svr image
+
+Upload the `signed.img` file from step 5 to image slot 0 of your board.  The location of image slot 0 varies by BSP.  For the nRF52dk, slot 0 is located at address 0xc000.
+
+The following gdb command uploads the image to 0xc000:
+```
+restore <path-to-signed.img> binary 0xc000
+```
+
+#### Step 7: Run it!
+
+The `smp_svr` app is ready to run.  Just reset your board and test the app with the mcumgr CLI tool:
+
+```
+$ mcumgr --conntype ble --connstring peer_name=Zephyr echo hello
+hello
+```

--- a/samples/smp_svr/mynewt/pkg.yml
+++ b/samples/smp_svr/mynewt/pkg.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+pkg.name: samples/smp_svr/mynewt
+pkg.type: app
+pkg.description: Simple BLE peripheral running an mcumgr SMP server.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps: 
+    - '@apache-mynewt-core/boot/bootutil'
+    - '@apache-mynewt-core/mgmt/newtmgr/transport/ble'
+    - '@apache-mynewt-core/mgmt/newtmgr/transport/nmgr_shell'
+    - '@apache-mynewt-core/net/nimble/controller'
+    - '@apache-mynewt-core/net/nimble/host'
+    - '@apache-mynewt-core/net/nimble/host/services/ans'
+    - '@apache-mynewt-core/net/nimble/host/services/gap'
+    - '@apache-mynewt-core/net/nimble/host/services/gatt'
+    - '@apache-mynewt-core/net/nimble/host/store/config'
+    - '@apache-mynewt-core/net/nimble/transport/ram'
+    - '@apache-mynewt-core/sys/console/full'
+    - '@apache-mynewt-core/sys/log/full'
+    - '@apache-mynewt-core/sys/stats/full'
+    - '@mynewt-mcumgr/cmd/fs_mgmt'
+    - '@mynewt-mcumgr/cmd/img_mgmt'
+    - '@mynewt-mcumgr/cmd/os_mgmt'
+    - '@mynewt-mcumgr/smp'

--- a/samples/smp_svr/mynewt/src/main.c
+++ b/samples/smp_svr/mynewt/src/main.c
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include "sysinit/sysinit.h"
+#include "bsp/bsp.h"
+#include "bsp/bsp.h"
+#include "config/config.h"
+#include "console/console.h"
+#include "hal/hal_gpio.h"
+#include "hal/hal_system.h"
+#include "os/os.h"
+
+/* BLE */
+#include "nimble/ble.h"
+#include "host/ble_hs.h"
+#include "services/gap/ble_svc_gap.h"
+
+/* smp_svr uses the first "peruser" log module. */
+#define SMP_SVR_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
+
+/* Convenience macro for logging to the smp_svr module. */
+#define SMP_SVR_LOG(lvl, ...) \
+    LOG_ ## lvl(&smp_svr_log, SMP_SVR_LOG_MODULE, __VA_ARGS__)
+
+/** Log data. */
+struct log smp_svr_log;
+
+static int smp_svr_gap_event(struct ble_gap_event *event, void *arg);
+
+void
+print_addr(const void *addr)
+{
+    const uint8_t *u8p;
+
+    u8p = addr;
+    SMP_SVR_LOG(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+                u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
+}
+
+/**
+ * Logs information about a connection to the console.
+ */
+static void
+smp_svr_print_conn_desc(struct ble_gap_conn_desc *desc)
+{
+    SMP_SVR_LOG(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+                desc->conn_handle, desc->our_ota_addr.type);
+    print_addr(desc->our_ota_addr.val);
+    SMP_SVR_LOG(INFO, " our_id_addr_type=%d our_id_addr=",
+                desc->our_id_addr.type);
+    print_addr(desc->our_id_addr.val);
+    SMP_SVR_LOG(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+                desc->peer_ota_addr.type);
+    print_addr(desc->peer_ota_addr.val);
+    SMP_SVR_LOG(INFO, " peer_id_addr_type=%d peer_id_addr=",
+                desc->peer_id_addr.type);
+    print_addr(desc->peer_id_addr.val);
+    SMP_SVR_LOG(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+                "encrypted=%d authenticated=%d bonded=%d\n",
+                desc->conn_itvl, desc->conn_latency,
+                desc->supervision_timeout,
+                desc->sec_state.encrypted,
+                desc->sec_state.authenticated,
+                desc->sec_state.bonded);
+}
+
+/**
+ * Enables advertising with the following parameters:
+ *     o General discoverable mode.
+ *     o Undirected connectable mode.
+ */
+static void
+smp_svr_advertise(void)
+{
+    struct ble_gap_adv_params adv_params;
+    struct ble_hs_adv_fields fields;
+    const char *name;
+    int rc;
+
+    /**
+     *  Set the advertisement data included in our advertisements:
+     *     o Flags (indicates advertisement type and other general info).
+     *     o Advertising tx power.
+     *     o Device name.
+     *     o 16-bit service UUIDs (alert notifications).
+     */
+
+    memset(&fields, 0, sizeof fields);
+
+    /* Advertise two flags:
+     *     o Discoverability in forthcoming advertisement (general)
+     *     o BLE-only (BR/EDR unsupported).
+     */
+    fields.flags = BLE_HS_ADV_F_DISC_GEN |
+                   BLE_HS_ADV_F_BREDR_UNSUP;
+
+    /* Indicate that the TX power level field should be included; have the
+     * stack fill this value automatically.  This is done by assiging the
+     * special value BLE_HS_ADV_TX_PWR_LVL_AUTO.
+     */
+    fields.tx_pwr_lvl_is_present = 1;
+    fields.tx_pwr_lvl = BLE_HS_ADV_TX_PWR_LVL_AUTO;
+
+    name = ble_svc_gap_device_name();
+    fields.name = (uint8_t *)name;
+    fields.name_len = strlen(name);
+    fields.name_is_complete = 1;
+
+    fields.uuids16 = (ble_uuid16_t[]){
+        BLE_UUID16_INIT(GATT_SVR_SVC_ALERT_UUID)
+    };
+    fields.num_uuids16 = 1;
+    fields.uuids16_is_complete = 1;
+
+    rc = ble_gap_adv_set_fields(&fields);
+    if (rc != 0) {
+        SMP_SVR_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        return;
+    }
+
+    /* Begin advertising. */
+    memset(&adv_params, 0, sizeof adv_params);
+    adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
+    adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
+    rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
+                           &adv_params, smp_svr_gap_event, NULL);
+    if (rc != 0) {
+        SMP_SVR_LOG(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        return;
+    }
+}
+
+/**
+ * The nimble host executes this callback when a GAP event occurs.  The
+ * application associates a GAP event callback with each connection that forms.
+ * smp_svr uses the same callback for all connections.
+ *
+ * @param event                 The type of event being signalled.
+ * @param ctxt                  Various information pertaining to the event.
+ * @param arg                   Application-specified argument; unuesd by
+ *                                  smp_svr.
+ *
+ * @return                      0 if the application successfully handled the
+ *                                  event; nonzero on failure.  The semantics
+ *                                  of the return code is specific to the
+ *                                  particular GAP event being signalled.
+ */
+static int
+smp_svr_gap_event(struct ble_gap_event *event, void *arg)
+{
+    struct ble_gap_conn_desc desc;
+    int rc;
+
+    switch (event->type) {
+    case BLE_GAP_EVENT_CONNECT:
+        /* A new connection was established or a connection attempt failed. */
+        SMP_SVR_LOG(INFO, "connection %s; status=%d ",
+                       event->connect.status == 0 ? "established" : "failed",
+                       event->connect.status);
+        if (event->connect.status == 0) {
+            rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+            assert(rc == 0);
+            smp_svr_print_conn_desc(&desc);
+
+#if MYNEWT_VAL(SMP_SVR_LE_PHY_SUPPORT)
+            phy_conn_changed(event->connect.conn_handle);
+#endif
+        }
+        SMP_SVR_LOG(INFO, "\n");
+
+        if (event->connect.status != 0) {
+            /* Connection failed; resume advertising. */
+            smp_svr_advertise();
+        }
+        return 0;
+
+    case BLE_GAP_EVENT_DISCONNECT:
+        SMP_SVR_LOG(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        smp_svr_print_conn_desc(&event->disconnect.conn);
+        SMP_SVR_LOG(INFO, "\n");
+
+#if MYNEWT_VAL(SMP_SVR_LE_PHY_SUPPORT)
+        phy_conn_changed(CONN_HANDLE_INVALID);
+#endif
+
+        /* Connection terminated; resume advertising. */
+        smp_svr_advertise();
+        return 0;
+
+    case BLE_GAP_EVENT_CONN_UPDATE:
+        /* The central has updated the connection parameters. */
+        SMP_SVR_LOG(INFO, "connection updated; status=%d ",
+                    event->conn_update.status);
+        rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+        assert(rc == 0);
+        smp_svr_print_conn_desc(&desc);
+        SMP_SVR_LOG(INFO, "\n");
+        return 0;
+
+    case BLE_GAP_EVENT_ADV_COMPLETE:
+        SMP_SVR_LOG(INFO, "advertise complete; reason=%d",
+                    event->adv_complete.reason);
+        smp_svr_advertise();
+        return 0;
+
+    case BLE_GAP_EVENT_ENC_CHANGE:
+        /* Encryption has been enabled or disabled for this connection. */
+        SMP_SVR_LOG(INFO, "encryption change event; status=%d ",
+                    event->enc_change.status);
+        rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+        assert(rc == 0);
+        smp_svr_print_conn_desc(&desc);
+        SMP_SVR_LOG(INFO, "\n");
+        return 0;
+
+    case BLE_GAP_EVENT_MTU:
+        SMP_SVR_LOG(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+                    event->mtu.conn_handle,
+                    event->mtu.channel_id,
+                    event->mtu.value);
+        return 0;
+
+    case BLE_GAP_EVENT_REPEAT_PAIRING:
+        /* We already have a bond with the peer, but it is attempting to
+         * establish a new secure link.  This app sacrifices security for
+         * convenience: just throw away the old bond and accept the new link.
+         */
+
+        /* Delete the old bond. */
+        rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
+        assert(rc == 0);
+        ble_store_util_delete_peer(&desc.peer_id_addr);
+
+        /* Return BLE_GAP_REPEAT_PAIRING_RETRY to indicate that the host should
+         * continue with the pairing operation.
+         */
+        return BLE_GAP_REPEAT_PAIRING_RETRY;
+    }
+
+    return 0;
+}
+
+static void
+smp_svr_on_reset(int reason)
+{
+    SMP_SVR_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+}
+
+static void
+smp_svr_on_sync(void)
+{
+    /* Begin advertising. */
+    smp_svr_advertise();
+}
+
+/**
+ * main
+ *
+ * The main task for the project. This function initializes the packages,
+ * then starts serving events from default event queue.
+ *
+ * @return int NOTE: this function should never return!
+ */
+int
+main(void)
+{
+    int rc;
+
+    /* Initialize OS */
+    sysinit();
+
+    /* Initialize the smp_svr log. */
+    log_register("smp_svr", &smp_svr_log, &log_console_handler, NULL,
+                 LOG_SYSLEVEL);
+
+    /* Initialize the NimBLE host configuration. */
+    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
+                 LOG_SYSLEVEL);
+    ble_hs_cfg.reset_cb = smp_svr_on_reset;
+    ble_hs_cfg.sync_cb = smp_svr_on_sync;
+    ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
+    ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
+
+    rc = gatt_svr_init();
+    assert(rc == 0);
+
+    /* Set the default device name. */
+    rc = ble_svc_gap_device_name_set("smp_svr");
+    assert(rc == 0);
+
+    conf_load();
+
+    /*
+     * As the last thing, process events from default event queue.
+     */
+    while (1) {
+        os_eventq_run(os_eventq_dflt_get());
+    }
+    return 0;
+}

--- a/samples/smp_svr/mynewt/syscfg.yml
+++ b/samples/smp_svr/mynewt/syscfg.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: apps/bleprph
+
+syscfg.vals:
+    # Disable central and observer roles.
+    BLE_ROLE_BROADCASTER: 1
+    BLE_ROLE_CENTRAL: 0
+    BLE_ROLE_OBSERVER: 0
+    BLE_ROLE_PERIPHERAL: 1
+
+    # Log reboot messages to a flash circular buffer.
+    REBOOT_LOG_FCB: 1
+    LOG_FCB: 1
+    CONFIG_FCB: 1
+
+    # OS main/default task
+    OS_MAIN_STACK_SIZE: 468
+
+    # Lots of smaller mbufs are required for newtmgr using typical BLE ATT MTU
+    # values.
+    MSYS_1_BLOCK_COUNT: 22
+    MSYS_1_BLOCK_SIZE: 110

--- a/samples/smp_svr/zephyr/CMakeLists.txt
+++ b/samples/smp_svr/zephyr/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Top-level CMakeLists.txt for the skeleton application.
+#
+# Copyright (c) 2017 Open Source Foundries Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This provides a basic application structure suitable for communication using
+# mcumgr.  It can be used as a starting point for new applications.
+
+# Zephyr uses Device Tree (DT) to describe some board hardware configuration.
+#
+# See the Zephyr documentation for more information on DT:
+# http://docs.zephyrproject.org/devices/dts/device_tree.html
+set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/dts.overlay")
+
+# Standard Zephyr application boilerplate.
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(NONE)
+
+assert_exists(DTC_OVERLAY_FILE)
+
+target_sources(app PRIVATE
+    src/main.c
+)
+
+zephyr_link_libraries_ifdef(CONFIG_FILE_SYSTEM_NFFS NFFS)
+zephyr_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/samples/smp_svr/zephyr/dts.overlay
+++ b/samples/smp_svr/zephyr/dts.overlay
@@ -1,0 +1,10 @@
+/*
+ * Basic Device Tree overlay file.
+ */
+
+/ {
+	chosen {
+		/* Use uart0 for the mcumgr UART transport. */
+		zephyr,uart-mcumgr = &uart0;
+	};
+};

--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -1,0 +1,45 @@
+# Enable mcumgr.
+CONFIG_MCUMGR=y
+
+# Some command handlers require a large stack.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+# Ensure an MCUboot-compatible binary is generated.
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Allow for large Bluetooth data packets.
+CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_RX_BUF_LEN=260
+
+# Enable the Bluetooth and shell mcumgr transports.
+CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_SHELL=y
+#CONFIG_MCUMGR_SMP_UART=y
+
+# Bluetooth support requires a net_buf user_data size >= 7.
+CONFIG_NET_BUF_USER_DATA_SIZE=7
+
+# Enable flash operations.
+CONFIG_FLASH=y
+
+# Enable the NFFS file system.
+CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_NFFS=y
+
+# Required by the `taskstat` command.
+CONFIG_THREAD_MONITOR=y
+
+# Enable statistics and statistic names.
+CONFIG_STATS=y
+CONFIG_STATS_NAMES=y
+
+# Enable all core commands.
+CONFIG_MCUMGR_CMD_FS_MGMT=y
+CONFIG_MCUMGR_CMD_IMG_MGMT=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_CMD_STAT_MGMT=y
+
+### nRF5 specific settings
+
+# Specify the location of the NFFS file system.
+CONFIG_FS_NFFS_FLASH_DEV_NAME="NRF5_FLASH_DRV_NAME"

--- a/samples/smp_svr/zephyr/prj.conf.tiny
+++ b/samples/smp_svr/zephyr/prj.conf.tiny
@@ -1,0 +1,49 @@
+### This configuration enables fewer settings than the default, making it
+### suitable for a device with 32kB of RAM and 72kB image slots (e.g.,
+### nRF51).
+
+# Enable mcumgr.
+CONFIG_MCUMGR=y
+
+# Some command handlers require a large stack.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+# Ensure an MCUboot-compatible binary is generated.
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Allow for large Bluetooth data packets.
+CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_RX_BUF_LEN=260
+
+# Enable the Bluetooth and UART mcumgr transports.
+CONFIG_MCUMGR_SMP_BT=y
+#CONFIG_MCUMGR_SMP_SHELL=y
+CONFIG_MCUMGR_SMP_UART=y
+
+# Bluetooth support requires a net_buf user_data size >= 7.
+CONFIG_NET_BUF_USER_DATA_SIZE=7
+
+# Enable flash operations.
+CONFIG_FLASH=y
+
+# Enable the NFFS file system.
+#CONFIG_FILE_SYSTEM=y
+#CONFIG_FILE_SYSTEM_NFFS=y
+
+# Required by the `taskstat` command.
+CONFIG_THREAD_MONITOR=y
+
+# Enable statistics and statistic names.
+CONFIG_STATS=y
+#CONFIG_STATS_NAMES=y
+
+# Enable all core commands.
+#CONFIG_MCUMGR_CMD_FS_MGMT=y
+CONFIG_MCUMGR_CMD_IMG_MGMT=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_CMD_STAT_MGMT=y
+
+### nRF5 specific settings
+
+# Specify the location of the NFFS file system.
+#CONFIG_FS_NFFS_FLASH_DEV_NAME="NRF5_FLASH"

--- a/samples/smp_svr/zephyr/src/main.c
+++ b/samples/smp_svr/zephyr/src/main.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <assert.h>
+#include <zephyr.h>
+#include <string.h>
+#include <stdlib.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/gatt.h>
+#include <stats.h>
+#include <mgmt/smp_bt.h>
+#include <mgmt/buf.h>
+
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+#include <device.h>
+#include <fs.h>
+#include "fs_mgmt/fs_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+#include "os_mgmt/os_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+#include "img_mgmt/img_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+#include "stat_mgmt/stat_mgmt.h"
+#endif
+
+#define DEVICE_NAME         CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN     (sizeof(DEVICE_NAME) - 1)
+
+/* Define an example stats group; approximates seconds since boot. */
+STATS_SECT_START(smp_svr_stats)
+STATS_SECT_ENTRY(ticks)
+STATS_SECT_END;
+
+/* Assign a name to the `ticks` stat. */
+STATS_NAME_START(smp_svr_stats)
+STATS_NAME(smp_svr_stats, ticks)
+STATS_NAME_END(smp_svr_stats);
+
+/* Define an instance of the stats group. */
+STATS_SECT_DECL(smp_svr_stats) smp_svr_stats;
+
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+static struct nffs_flash_desc flash_desc;
+
+static struct fs_mount_t nffs_mnt = {
+	.type = FS_NFFS,
+	.mnt_point = "/nffs",
+	.fs_data = &flash_desc,
+};
+#endif
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86,
+		      0xd3, 0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
+};
+
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
+};
+
+static void advertise(void)
+{
+	int rc;
+
+	bt_le_adv_stop();
+
+	rc = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
+			     sd, ARRAY_SIZE(sd));
+	if (rc) {
+		printk("Advertising failed to start (rc %d)\n", rc);
+		return;
+	}
+
+	printk("Advertising successfully started\n");
+}
+
+static void connected(struct bt_conn *conn, u8_t err)
+{
+	if (err) {
+		printk("Connection failed (err %u)\n", err);
+	} else {
+		printk("Connected\n");
+	}
+}
+
+static void disconnected(struct bt_conn *conn, u8_t reason)
+{
+	printk("Disconnected (reason %u)\n", reason);
+	advertise();
+}
+
+static struct bt_conn_cb conn_callbacks = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void bt_ready(int err)
+{
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	printk("Bluetooth initialized\n");
+
+	advertise();
+}
+
+void main(void)
+{
+	struct device *flash_dev;
+	int rc;
+
+	rc = STATS_INIT_AND_REG(smp_svr_stats, STATS_SIZE_32, "smp_svr_stats");
+	assert(rc == 0);
+
+	/* Register the built-in mcumgr command handlers. */
+#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
+	flash_dev = device_get_binding(CONFIG_FS_NFFS_FLASH_DEV_NAME);
+	if (!flash_dev) {
+        printk("Error getting NFFS flash device binding\n");
+	} else {
+		/* set backend storage dev */
+		nffs_mnt.storage_dev = flash_dev;
+
+		rc = fs_mount(&nffs_mnt);
+		if (rc < 0) {
+			printk("Error mounting nffs [%d]\n", rc);
+		}
+	}
+
+	fs_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+	os_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+	img_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+	stat_mgmt_register_group();
+#endif
+
+	/* Enable Bluetooth. */
+	rc = bt_enable(bt_ready);
+	if (rc != 0) {
+		printk("Bluetooth init failed (err %d)\n", rc);
+		return;
+	}
+	bt_conn_cb_register(&conn_callbacks);
+
+	/* Initialize the Bluetooth mcumgr transport. */
+	smp_bt_register();
+
+	/* The system work queue handles all incoming mcumgr requests.  Let the
+	 * main thread idle while the mcumgr server runs.
+	 */
+	while (1) {
+		k_sleep(1000);
+		STATS_INC(smp_svr_stats, ticks);
+	}
+}

--- a/smp/pkg.yml
+++ b/smp/pkg.yml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: smp
+pkg.description: Server-side simple management protocol (SMP) functionality.
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - '@apache-mynewt-core/encoding/cborattr'
+    - '@apache-mynewt-core/kernel/os'
+    - '@apache-mynewt-core/util/mem'
+    - '@mynewt-mcumgr/mgmt'
+    - '@mynewt-mcumgr/smp'
+
+pkg.deps.NEWTMGR_BLE_HOST:
+    - '@apache-mynewt-core/mgmt/newtmgr/transport/ble'
+
+pkg.apis:
+    - newtmgr
+
+pkg.init:
+    smp_pkg_init: 500

--- a/transport/smp-console.md
+++ b/transport/smp-console.md
@@ -5,8 +5,9 @@ transmitted over text consoles.
 
 ## Overview
 
-Mcumgr packets sent over serial are fragmented into frames of 128 bytes or
-fewer.
+Mcumgr packets sent over serial are fragmented into frames of 127 bytes or
+fewer.  This 127-byte maximum applies to the entire frame, including header,
+CRC, and terminating newline.
 
 The initial frame in a packet has the following format:
 


### PR DESCRIPTION
Synchronization was done via
git merge origin/master
--allow-unrelated-histories
--strategy-option theirs

As histories are merged now so future upmerge from/backmerge to  mynewt-mcumgr will be easy.
code base effect is the same as in #5

Origin: mcumgr
License: Apache 2.0
URL: https://github.com/apache/mynewt-mcumgr
Commit: 607995c
Purpose: code-base synchronization
Maintained-by: External

Signed-off-by: Andrzej Puzdrowski andrzej.puzdrowski@nordicsemi.no