### PR TITLE
include: Fix zephyr includes to use non-deprecated header locations

### DIFF
--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <fs.h>
+#include <fs/fs.h>
 #include <mgmt/mgmt.h>
 #include <fs_mgmt/fs_mgmt_impl.h>
 

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <flash.h>
-#include <flash_map.h>
+#include <storage/flash_map.h>
 #include <zephyr.h>
 #include <soc.h>
 #include <init.h>

--- a/cmd/log_mgmt/port/zephyr/src/zephyr_log_mgmt.c
+++ b/cmd/log_mgmt/port/zephyr/src/zephyr_log_mgmt.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <misc/util.h>
+#include <sys/util.h>
 #include <logging/mdlog.h>
 #include <mgmt/mgmt.h>
 #include <log_mgmt/log_mgmt.h>

--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -18,7 +18,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/reboot.h>
+#include <sys/reboot.h>
 #include <debug/object_tracing.h>
 #include <kernel_structs.h>
 #include <mgmt/mgmt.h>

--- a/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
+++ b/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <misc/util.h>
+#include <sys/util.h>
 #include <stats.h>
 #include <mgmt/mgmt.h>
 #include <stat_mgmt/stat_mgmt.h>


### PR DESCRIPTION
Fix includes to use <sys/FOO.h> instead of <misc/FOO.h> as well as a few
<fs/fs.h> instead of <fs.h> and <storage/flash_map.h> instead of
<flash_map.h>

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>