### PR TITLE
include: Fix zephyr includes to use non-deprecated header locations

### DIFF
--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -18,7 +18,7 @@
  */
 
 #include <zephyr.h>
-#include <sys/reboot.h>
+#include <power/reboot.h>
 #include <debug/object_tracing.h>
 #include <kernel_structs.h>
 #include <mgmt/mgmt.h>

--- a/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
+++ b/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
@@ -18,7 +18,7 @@
  */
 
 #include <sys/util.h>
-#include <stats.h>
+#include <stats/stats.h>
 #include <mgmt/mgmt.h>
 #include <stat_mgmt/stat_mgmt.h>
 #include <stat_mgmt/stat_mgmt_impl.h>


### PR DESCRIPTION
Fix <stats.h> -> <stats/stats.h>,
Fix <sys/reboot.h> -> <power/reboot.h>

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>