### PR TITLE
Enabling Zephyr/mynewt-core version of tinycbor

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -385,7 +385,7 @@ cbor_read_flat_attrs(const uint8_t *data, int len,
     CborError err;
 
     cbor_buf_reader_init(&reader, data, len);
-    err = cbor_parser_cust_reader_init(&reader.r, 0, &parser, &value);
+    err = cbor_parser_init(&reader.r, 0, &parser, &value);
     if (err != CborNoError) {
         return -1;
     }

--- a/cmd/log_mgmt/src/log_mgmt.c
+++ b/cmd/log_mgmt/src/log_mgmt.c
@@ -105,7 +105,7 @@ log_mgmt_cb_encode(const struct log_mgmt_entry *entry, void *arg)
     /*** First, determine if this entry would fit. */
 
     cbor_cnt_writer_init(&cnt_writer);
-    cbor_encoder_cust_writer_init(&cnt_encoder, &cnt_writer.enc, 0);
+    cbor_encoder_init(&cnt_encoder, &cnt_writer.enc, 0);
     rc = log_mgmt_encode_entry(&cnt_encoder, entry, &entry_len);
     if (rc != 0) {
         return rc;

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -144,13 +144,13 @@ mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct mgmt_streamer *streamer)
 {
     int rc;
 
-    rc = cbor_parser_cust_reader_init(streamer->reader, 0, &ctxt->parser,
+    rc = cbor_parser_init(streamer->reader, 0, &ctxt->parser,
                                       &ctxt->it);
     if (rc != CborNoError) {
         return mgmt_err_from_cbor(rc);
     }
 
-    cbor_encoder_cust_writer_init(&ctxt->encoder, streamer->writer, 0);
+    cbor_encoder_init(&ctxt->encoder, streamer->writer, 0);
 
     return 0;
 }


### PR DESCRIPTION
_NOTE: Umbrella PR that gathers required changes to other project is here:
https://github.com/zephyrproject-rtos/zephyr/pull/21825_

This PR provides changes required by PR https://github.com/zephyrproject-rtos/tinycbor/pull/11, which replaces Tinycbor for used by Zephyr by the mynewt-core version.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>