### PR TITLE
cmd: img_mgmt: fix driver include path

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <flash.h>
+#include <drivers/flash.h>
 #include <storage/flash_map.h>
 #include <zephyr.h>
 #include <soc.h>


### PR DESCRIPTION
In support of zephyrproject-rtos/zephyr#21776 we need to give the full path to the flash driver header.