### PR TITLE
kconfig: Fix broken ref. to THREAD_STACK_INFO from Zephyr

### DIFF
--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -67,7 +67,7 @@ os_mgmt_impl_task_info(int idx, struct os_mgmt_task_info *out_info)
     out_info->oti_prio = thread->base.prio;
     out_info->oti_taskid = idx;
     out_info->oti_state = thread->base.thread_state;
-#ifdef THREAD_STACK_INFO
+#ifdef CONFIG_THREAD_STACK_INFO
     out_info->oti_stksize = thread->stack_info.size / 4;
 #endif
 


### PR DESCRIPTION
The CONFIG_ prefix was missing.

Found with a work-in-progress scripts/kconfig/lint.py check.

This symbol is defined in kernel/Kconfig in Zephyr.