### PR TITLE
[DNM] cmd: img_mgmt: update to flash_img using fbw

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -292,7 +292,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 		}
 	}
 
-	if (offset != ctx->bytes_written + ctx->buf_bytes) {
+	if (offset != ctx->stream.bytes_written + ctx->stream.buf_bytes) {
 		return MGMT_ERR_EUNKNOWN;
 	}
 


### PR DESCRIPTION
flash_img.c is now using fbw as storage backend, update
pointers to member variables to reflect this.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>