### PR TITLE
snapshot: Update mcumgr to commit f3b171f2 from the upstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ zephyr_library_link_libraries(MCUMGR)
 
 target_link_libraries(MCUMGR INTERFACE
   zephyr_interface
-  TINYCBOR
   )
 
 endif()


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream
 apache/mynewt-mcumgr: c4919dab456ba383431b1936a6fd7524486f9718
and the current top on the upstream:
 apache/mynewt-mcumgr: f3b171f2d6d50b0b696f1307bb18e748727fbc80

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>