### PR TITLE
snapshot: Update mcumgr to commit 40341abe from the upstream

### DIFF
--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -91,6 +91,6 @@ zephyr_os_mgmt_reset_cb(struct k_timer *timer)
 int
 os_mgmt_impl_reset(unsigned int delay_ms)
 {
-    k_timer_start(&zephyr_os_mgmt_reset_timer, K_MSEC(delay_ms), 0);
+    k_timer_start(&zephyr_os_mgmt_reset_timer, K_MSEC(delay_ms), K_NO_WAIT);
     return 0;
 }

--- a/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/include/mgmt/mgmt.h
@@ -49,6 +49,7 @@ extern "C" {
 #define MGMT_GROUP_ID_SPLIT     6
 #define MGMT_GROUP_ID_RUN       7
 #define MGMT_GROUP_ID_FS        8
+#define MGMT_GROUP_ID_SHELL     9
 #define MGMT_GROUP_ID_PERUSER   64
 
 /**

--- a/samples/omp_svr/mynewt/syscfg.yml
+++ b/samples/omp_svr/mynewt/syscfg.yml
@@ -35,7 +35,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 468
+    OS_MAIN_STACK_SIZE: 568
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
 apache/mynewt-mcumgr f3b171f2d6d50b0b696f1307bb18e748727fbc80
and the current top on the upstream:
 apache/mynewt-mcumgr 40341abeeac9c93b4aa59c20ee183376c7920d7e

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>