### PR TITLE
snapshot: Update mcumgr to commit 9f6555ad from the upstream

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -292,7 +292,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 		}
 	}
 
-	if (offset != ctx->bytes_written + ctx->buf_bytes) {
+	if (offset != ctx->stream.bytes_written + ctx->stream.buf_bytes) {
 		return MGMT_ERR_EUNKNOWN;
 	}
 


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
 apache/mynewt-mcumgr 40341abeeac9c93b4aa59c20ee183376c7920d7e
and the current top on the upstream:
 apache/mynewt-mcumgr 9f6555ad032d16314fedc813824e7a521535c71e

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
