### PR TITLE
snapshot: Update mcumgr to commit 7658d09f from the upstream

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -40,7 +40,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
  * Determines if the specified area of flash is completely unwritten.
  */
 static int
-zephyr_img_mgmt_flash_check_empty(u8_t fa_id, bool *out_empty)
+zephyr_img_mgmt_flash_check_empty(uint8_t fa_id, bool *out_empty)
 {
     const struct flash_area *fa;
     uint32_t data[16];
@@ -88,10 +88,10 @@ zephyr_img_mgmt_flash_check_empty(u8_t fa_id, bool *out_empty)
 /**
  * Get flash_area ID for a image slot number.
  */
-static u8_t
+static uint8_t
 zephyr_img_mgmt_flash_area_id(int slot)
 {
-    u8_t fa_id;
+    uint8_t fa_id;
 
     switch (slot) {
     case 0:

--- a/samples/smp_svr/zephyr/src/main.c
+++ b/samples/smp_svr/zephyr/src/main.c
@@ -95,7 +95,7 @@ static void advertise(struct k_work *work)
 	printk("Advertising successfully started\n");
 }
 
-static void connected(struct bt_conn *conn, u8_t err)
+static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
 		printk("Connection failed (err 0x%02x)\n", err);
@@ -104,7 +104,7 @@ static void connected(struct bt_conn *conn, u8_t err)
 	}
 }
 
-static void disconnected(struct bt_conn *conn, u8_t reason)
+static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02x)\n", reason);
 	k_work_submit(&advertise_work);


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
 apache/mynewt-mcumgr 3fdb7fe0a59dd879f81569a4fb36ea4b44b83792
and the current top on the upstream:
 apache/mynewt-mcumgr 7658d09f1c6ee2b778390854a9d90d74b39e9fca

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>