### PR TITLE
snapshot: Update mcumgr to commit 32827ad6 from the upstream

### DIFF
--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -49,9 +49,9 @@ fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
     ssize_t bytes_read;
     int rc;
 
-    rc = fs_open(&file, path);
+    rc = fs_open(&file, path, FS_O_READ);
     if (rc != 0) {
-        return MGMT_ERR_EUNKNOWN;
+        return MGMT_ERR_ENOENT;
     }
 
     rc = fs_seek(&file, offset, FS_SEEK_SET);
@@ -123,7 +123,7 @@ fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
         }
     }
 
-    rc = fs_open(&file, path);
+    rc = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -333,10 +333,11 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     /* align requested erase size to the erase-block-size */
     struct device *dev = flash_area_get_device(fa);
     struct flash_pages_info page;
+    off_t page_offset = fa->fa_off + num_bytes - 1;
 
-    rc = flash_get_page_info_by_offs(dev, fa->fa_off + num_bytes -1, &page);
+    rc = flash_get_page_info_by_offs(dev, page_offset, &page);
     if (rc != 0) {
-        LOG_ERR("bad offset (0x%x)", fa->fa_off + num_bytes -1);
+        LOG_ERR("bad offset (0x%lx)", (long)page_offset);
         rc = MGMT_ERR_EUNKNOWN;
         goto end_fa;
     }
@@ -346,13 +347,13 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     rc = flash_area_erase(fa, 0, erase_size);
 
     if (rc != 0) {
-        LOG_ERR("image slot erase of 0x%x bytes failed (err %d)", erase_size,
+        LOG_ERR("image slot erase of 0x%zx bytes failed (err %d)", erase_size,
                 rc);
         rc = MGMT_ERR_EUNKNOWN;
         goto end_fa;
     }
 
-    LOG_INF("Erased 0x%x bytes of image slot", erase_size);
+    LOG_INF("Erased 0x%zx bytes of image slot", erase_size);
 
     /* erase the image trailer area if it was not erased */
     off = BOOT_TRAILER_IMG_STATUS_OFFS(fa);
@@ -364,13 +365,13 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
 
         rc = flash_area_erase(fa, off, erase_size);
         if (rc != 0) {
-            LOG_ERR("image slot trailer erase of 0x%x bytes failed (err %d)",
+            LOG_ERR("image slot trailer erase of 0x%zx bytes failed (err %d)",
                     erase_size, rc);
             rc = MGMT_ERR_EUNKNOWN;
             goto end_fa;
         }
 
-        LOG_INF("Erased 0x%x bytes of image slot trailer", erase_size);
+        LOG_INF("Erased 0x%zx bytes of image slot trailer", erase_size);
     }
 
     rc = 0;


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
 apache/mynewt-mcumgr 7658d09f1c6ee2b778390854a9d90d74b39e9fca
and the current top on the upstream:
 apache/mynewt-mcumgr 32827ad6db87042c0979c18eeef2afa7714391e5

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

~~Zephyr West.yml update reviewed here: https://github.com/zephyrproject-rtos/zephyr/pull/27116~~
Due to required changes to fs API, the snapshot update is reviewed/tested here: https://github.com/zephyrproject-rtos/zephyr/pull/26305