### PR TITLE
snapshot: Update mcumgr to commit 8d087a7e from the upstream

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -331,7 +331,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     }
 
     /* align requested erase size to the erase-block-size */
-    struct device *dev = flash_area_get_device(fa);
+    const struct device *dev = flash_area_get_device(fa);
     struct flash_pages_info page;
     off_t page_offset = fa->fa_off + num_bytes - 1;
 
@@ -343,7 +343,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     }
 
     size_t erase_size = page.start_offset + page.size - fa->fa_off;
-    
+
     rc = flash_area_erase(fa, 0, erase_size);
 
     if (rc != 0) {

--- a/protocol.md
+++ b/protocol.md
@@ -83,6 +83,18 @@ type NmpHdr struct {
 - **`Id`**: The command ID to send. Commands in the default `Group` are defined
   [here](https://github.com/apache/mynewt-mcumgr/blob/master/mgmt/include/mgmt/mgmt.h).
 
+SMP header (Little Endian)
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|  OP |   Res.  |      Flags    |             Length            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|            Group ID           |    Sequence   |   Command ID  |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
 #### `Data` Payload
 
 If `nh_len` (`Len` in nmp) is non-zero, the `nh_len` byte payload (referred to as **`Data`** in this document) immediately follows the frame header.


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
 apache/mynewt-mcumgr 3fdb7fe0a59dd879f81569a4fb36ea4b44b83792
and the current top on the upstream:
 apache/mynewt-mcumgr 8d087a7e0e5485394419d10051606c92d68d2111

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>