### PR TITLE
cmd: img_mgmt: remove const qualifier to prevent compilation warning

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -331,7 +331,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     }
 
     /* align requested erase size to the erase-block-size */
-    const struct device *dev = flash_area_get_device(fa);
+    struct device *dev = flash_area_get_device(fa);
     struct flash_pages_info page;
     off_t page_offset = fa->fa_off + num_bytes - 1;
 


### PR DESCRIPTION
This commit prevents compilation warning [-Wdiscarded-qualifiers],
by removing const qualifier in pointer initialization.

Signed-off-by: Filip Trajkovic <filip.trajkovic@proglove.de>