### PR TITLE
[RFC][DNM] zephyr: Add support for image ROM address verification

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/image.h
+++ b/cmd/img_mgmt/include/img_mgmt/image.h
@@ -34,6 +34,7 @@ extern "C" {
 
 /** Image header flags. */
 #define IMAGE_F_NON_BOOTABLE        0x00000010 /* Split image app. */
+#define IMAGE_F_ROM_FIXED_ADDR      0x00000100
 
 /** Image trailer TLV types. */
 #define IMAGE_TLV_SHA256            0x10   /* SHA256 of image hdr and body */

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -259,6 +259,7 @@ extern const char *img_mgmt_err_str_flash_open_failed;
 extern const char *img_mgmt_err_str_flash_erase_failed;
 extern const char *img_mgmt_err_str_flash_write_failed;
 extern const char *img_mgmt_err_str_downgrade;
+extern const char *img_mgmt_err_str_image_bad_flash_addr;
 #else
 #define img_mgmt_error_rsp(ctxt, rc, rsn)             (rc)
 #define img_mgmt_err_str_app_reject                   NULL
@@ -269,6 +270,7 @@ extern const char *img_mgmt_err_str_downgrade;
 #define img_mgmt_err_str_flash_erase_failed           NULL
 #define img_mgmt_err_str_flash_write_failed           NULL
 #define img_mgmt_err_str_downgrade                    NULL
+#define img_mgmt_err_str_image_bad_flash_addr         NULL
 #endif
 
 #ifdef __cplusplus

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -495,6 +495,23 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
             return MGMT_ERR_ENOMEM;
         }
 
+
+        if (hdr->ih_flags & IMAGE_F_ROM_FIXED_ADDR) {
+            rc = flash_area_open(action->area_id, &fa);
+            if (rc) {
+                *errstr = img_mgmt_err_str_flash_open_failed;
+                return MGMT_ERR_EUNKNOWN;
+            }
+
+            if (fa->fa_off != hdr->ih_load_addr) {
+                *errstr = img_mgmt_err_str_image_bad_flash_addr;
+                return MGMT_ERR_EUNKNOWN;
+            }
+
+            flash_area_close(fa);
+        }
+
+
         if (req->upgrade) {
             /* User specified upgrade-only.  Make sure new image version is
              * greater than that of the currently running image.

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -72,6 +72,7 @@ const char *img_mgmt_err_str_flash_open_failed = "fa open fail";
 const char *img_mgmt_err_str_flash_erase_failed = "fa erase fail";
 const char *img_mgmt_err_str_flash_write_failed = "fa write fail";
 const char *img_mgmt_err_str_downgrade = "downgrade";
+const char *img_mgmt_err_str_image_bad_flash_addr = "img addr mismatch";
 #endif
 
 /**


### PR DESCRIPTION
The commit adds IMAGE_F_ROM_FIXED_ADDR flag that allows to use
ih_load_addr to identify the flash address the image is intendant to
start at.
The code, that supports this flag, will reject image before attempting
flash write if slot address differs from the base address of the image.
The feature can be used to mark Direct-XIP images with slot address
they are intended for.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

NOTE: This PR is here temporarily as a part of this draft: zephyrproject-rtos/zephyr#29974