### PR TITLE
zephyr: link with MCUBOOT_BOOTUTIL library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,5 +30,6 @@ zephyr_library_link_libraries(MCUMGR)
 target_link_libraries(MCUMGR INTERFACE
   zephyr_interface
   )
+target_link_libraries(MCUMGR INTERFACE MCUBOOT_BOOTUTIL)
 
 endif()


### PR DESCRIPTION
Mcumgr use some defines which are originated from
MCUboot and are copied by zephyr. Linking with
he library allow to use original definition.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>