### PR TITLE
snapshot: Update mcumgr to commit b92aa0b8c9 from upstream

### DIFF
--- a/cborattr/include/cborattr/cborattr.h
+++ b/cborattr/include/cborattr/cborattr.h
@@ -48,6 +48,7 @@ typedef enum CborAttrType {
     CborAttrByteStringType,
     CborAttrTextStringType,
     CborAttrBooleanType,
+    CborAttrHalfFloatType,
     CborAttrFloatType,
     CborAttrDoubleType,
     CborAttrArrayType,
@@ -85,6 +86,9 @@ struct cbor_array_t {
         struct {
             double *store;
         } reals;
+        struct{
+            uint16_t *store;
+        } halffloats;
         struct {
             bool *store;
         } booleans;
@@ -99,6 +103,7 @@ struct cbor_attr_t {
     union {
         long long int *integer;
         long long unsigned int *uinteger;
+        uint16_t *halffloat;
         double *real;
         float *fval;
         char *string;
@@ -116,6 +121,7 @@ struct cbor_attr_t {
         double real;
         bool boolean;
         float fval;
+        uint16_t halffloat;
     } dflt;
     size_t len;
     bool nodefault;
@@ -139,6 +145,7 @@ struct cbor_out_val_t {
         long long unsigned int uinteger;
         double real;
         float fval;
+        uint16_t halffloat;
         const char *string;
         bool boolean;
         struct {

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -67,6 +67,11 @@ valid_attr_type(CborType ct, CborAttrType at)
         }
 	break;
 #if FLOAT_SUPPORT
+    case CborAttrHalfFloatType:
+        if (ct == CborHalfFloatType) {
+            return 1;
+        }
+        break;
     case CborAttrFloatType:
         if (ct == CborFloatType) {
             return 1;
@@ -120,6 +125,9 @@ cbor_target_address(const struct cbor_attr_t *cursor,
             targetaddr = (char *)&cursor->addr.uinteger[offset];
             break;
 #if FLOAT_SUPPORT
+        case CborAttrHalfFloatType:
+            targetaddr = (char *)&cursor->addr.halffloat[offset];
+            break;
         case CborAttrFloatType:
             targetaddr = (char *)&cursor->addr.fval[offset];
             break;
@@ -180,6 +188,9 @@ cbor_internal_read_object(CborValue *root_value,
                     memcpy(lptr, &cursor->dflt.boolean, sizeof(bool));
                     break;
 #if FLOAT_SUPPORT
+                case CborAttrHalfFloatType:
+                    memcpy(lptr, &cursor->dflt.halffloat, sizeof(uint16_t));
+                    break;
                 case CborAttrFloatType:
                     memcpy(lptr, &cursor->dflt.fval, sizeof(float));
                     break;
@@ -261,6 +272,9 @@ cbor_internal_read_object(CborValue *root_value,
                 err |= cbor_value_get_uint64(&cur_value, lptr);
                 break;
 #if FLOAT_SUPPORT
+            case CborAttrHalfFloatType:
+                err |= cbor_value_get_half_float(&cur_value, lptr);
+                break;
             case CborAttrFloatType:
                 err |= cbor_value_get_float(&cur_value, lptr);
                 break;
@@ -332,6 +346,10 @@ cbor_read_array(struct CborValue *value, const struct cbor_array_t *arr)
             err |= cbor_value_get_uint64(&elem, lptr);
             break;
 #if FLOAT_SUPPORT
+        case CborAttrHalfFloatType:
+            lptr = &arr->arr.halffloats.store[off];
+            err |= cbor_value_get_half_float(&elem, lptr);
+            break;
         case CborAttrFloatType:
         case CborAttrDoubleType:
             lptr = &arr->arr.reals.store[off];
@@ -491,6 +509,10 @@ cbor_write_val(struct CborEncoder *enc, const struct cbor_out_val_t *val)
         break;
 
 #if FLOAT_SUPPORT
+    case CborAttrHalfFloatType:
+        rc = cbor_encode_half_float(enc, &val->halffloat);
+        break;
+
     case CborAttrFloatType:
         rc = cbor_encode_float(enc, val->fval);
         break;

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -120,6 +120,11 @@ struct img_mgmt_upload_action {
 void img_mgmt_register_group(void);
 
 /**
+ * @brief Unregisters the image management command handler group.
+ */ 
+void img_mgmt_unregister_group(void);
+
+/*
  * @brief Read info of an image give the slot number
  *
  * @param image_slot     Image slot to read info from

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -194,14 +194,16 @@ img_mgmt_impl_erase_slot(void)
     bool empty;
     int rc;
 
-    rc = zephyr_img_mgmt_flash_check_empty(FLASH_AREA_ID(image_1),
-                                           &empty);
+    /* Select non-active slot */
+    const int best_id = img_mgmt_find_best_area_id();
+
+    rc = zephyr_img_mgmt_flash_check_empty(best_id, &empty);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }
 
     if (!empty) {
-        rc = boot_erase_img_bank(FLASH_AREA_ID(image_1));
+        rc = boot_erase_img_bank(best_id);
         if (rc != 0) {
             return MGMT_ERR_EUNKNOWN;
         }
@@ -290,7 +292,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 			}
 		}
 #endif
-		rc = flash_img_init(ctx);
+		rc = flash_img_init_id(ctx, img_mgmt_find_best_area_id());
 
 		if (rc != 0) {
 			return MGMT_ERR_EUNKNOWN;
@@ -328,7 +330,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
         goto end;
     }
 
-    rc = flash_area_open(FLASH_AREA_ID(image_1), &fa);
+    rc = flash_area_open(img_mgmt_find_best_area_id(), &fa);
     if (rc != 0) {
         LOG_ERR("Can't bind to the flash area (err %d)", rc);
         rc = MGMT_ERR_EUNKNOWN;

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -608,3 +608,9 @@ img_mgmt_register_group(void)
 {
     mgmt_register_group(&img_mgmt_group);
 }
+
+void
+img_mgmt_unregister_group(void)
+{
+    mgmt_unregister_group(&img_mgmt_group);
+}

--- a/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
+++ b/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
@@ -89,7 +89,8 @@ os_mgmt_impl_task_info(int idx, struct os_mgmt_task_info *out_info)
     out_info->oti_last_checkin = task->t_sanity_check.sc_checkin_last;
     out_info->oti_next_checkin = task->t_sanity_check.sc_checkin_last +
                                  task->t_sanity_check.sc_checkin_itvl;
-    strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name);
+    strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name - 1);
+    out_info->oti_name[sizeof out_info->oti_name - 1] = '\0';
 
     return 0;
 }

--- a/mgmt/include/mgmt/mgmt.h
+++ b/mgmt/include/mgmt/mgmt.h
@@ -367,6 +367,14 @@ void mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf);
 void mgmt_register_group(struct mgmt_group *group);
 
 /**
+ * @brief Unregisters a full command group.
+ *
+ * @param group                 The group to register.
+ */
+void
+mgmt_unregister_group(struct mgmt_group *group);
+
+/**
  * @brief Finds a registered command handler.
  *
  * @param group_id              The group of the command to find.

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -71,6 +71,35 @@ mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf)
     streamer->cfg->free_buf(buf, streamer->cb_arg);
 }
 
+void
+mgmt_unregister_group(struct mgmt_group *group)
+{
+    struct mgmt_group *curr = mgmt_group_list, *prev = NULL;
+
+    if (!group) {
+        return;
+    }
+
+    if (curr == group) {
+        mgmt_group_list = curr->mg_next;
+        return;
+    }
+
+    while (curr && curr != group) {
+        prev = curr;
+        curr = curr->mg_next;
+    }
+
+    if (!prev || !curr) {
+        return;
+    }
+
+    prev->mg_next = curr->mg_next;
+    if (curr->mg_next == NULL) {
+        mgmt_group_list_end = curr;
+    }
+}
+
 static struct mgmt_group *
 mgmt_find_group(uint16_t group_id, uint16_t command_id)
 {

--- a/samples/omp_svr/mynewt/src/main.c
+++ b/samples/omp_svr/mynewt/src/main.c
@@ -56,7 +56,6 @@
 /* Task 1 */
 #define TASK1_PRIO (8)
 #define TASK1_STACK_SIZE    OS_STACK_ALIGN(192)
-#define MAX_CBMEM_BUF 600
 static struct os_task task1;
 static volatile int g_task1_loops;
 


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 74e77ad08090c0e389a27118fdebe20783dca2e4
and the current top of the upstream:
  apache/mynewt-mcumgr b92aa0b8c999afa285b83012cd5dd76e33a2c03a

This includes following changes in common area that affect Zephyr:
-  fb489e1f mgmt: Add support for un-registering a group along with the same support in img_mgmt
-  c8151d80 zephyr: Rely on img_mgmt_find_best_area_id to select update partition
-  b92aa0b8 Fix encoding usage for halffloat

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>