### PR TITLE
snapshot: Update mcumgr to commit e289eaddc9 from upstream

### DIFF
--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -49,6 +49,7 @@ fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
     ssize_t bytes_read;
     int rc;
 
+    fs_file_t_init(&file);
     rc = fs_open(&file, path, FS_O_READ);
     if (rc != 0) {
         return MGMT_ERR_ENOENT;
@@ -123,6 +124,7 @@ fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
         }
     }
 
+    fs_file_t_init(&file);
     rc = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -46,32 +46,32 @@ img_mgmt_state_flags(int query_slot)
     swap_type = img_mgmt_impl_swap_type();
     switch (swap_type) {
     case IMG_MGMT_SWAP_TYPE_NONE:
-        if (query_slot == 0) {
+        if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
             flags |= IMG_MGMT_STATE_F_CONFIRMED;
             flags |= IMG_MGMT_STATE_F_ACTIVE;
         }
         break;
 
     case IMG_MGMT_SWAP_TYPE_TEST:
-        if (query_slot == 0) {
+        if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
             flags |= IMG_MGMT_STATE_F_CONFIRMED;
-        } else if (query_slot == 1) {
+        } else {
             flags |= IMG_MGMT_STATE_F_PENDING;
         }
         break;
 
     case IMG_MGMT_SWAP_TYPE_PERM:
-        if (query_slot == 0) {
+        if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
             flags |= IMG_MGMT_STATE_F_CONFIRMED;
-        } else if (query_slot == 1) {
+        } else {
             flags |= IMG_MGMT_STATE_F_PENDING | IMG_MGMT_STATE_F_PERMANENT;
         }
         break;
 
     case IMG_MGMT_SWAP_TYPE_REVERT:
-        if (query_slot == 0) {
+        if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
             flags |= IMG_MGMT_STATE_F_ACTIVE;
-        } else if (query_slot == 1) {
+        } else {
             flags |= IMG_MGMT_STATE_F_CONFIRMED;
         }
         break;
@@ -79,7 +79,7 @@ img_mgmt_state_flags(int query_slot)
 
     /* Slot 0 is always active. */
     /* XXX: The slot 0 assumption only holds when running from flash. */
-    if (query_slot == 0) {
+    if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
         flags |= IMG_MGMT_STATE_F_ACTIVE;
     }
 
@@ -300,7 +300,7 @@ img_mgmt_state_write(struct mgmt_ctxt *ctxt)
     /* Determine which slot is being operated on. */
     if (hash_len == 0) {
         if (confirm) {
-            slot = 0;
+            slot = IMG_MGMT_BOOT_CURR_SLOT;
         } else {
             /* A 'test' without a hash is invalid. */
             return MGMT_ERR_EINVAL;
@@ -312,7 +312,7 @@ img_mgmt_state_write(struct mgmt_ctxt *ctxt)
         }
     }
 
-    if (slot == 0 && confirm) {
+    if (slot == IMG_MGMT_BOOT_CURR_SLOT && confirm) {
         /* Confirm current setup. */
         rc = img_mgmt_state_confirm();
     } else {


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr b92aa0b8c999afa285b83012cd5dd76e33a2c03a
and the current top of the upstream:
  apache/mynewt-mcumgr e289eaddc9b8e238b5683359a6b3207c70c2c0e7

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Commits affecting Zephyr that are included with the snapshot:
 * 99f9fd6 img_mgmt: Use IMG_MGMT_BOOT_CURR_SLOT as current running slot ID (enhancement)
 * 6f52fd9 zephyr: fix initialization of file struct **(bug fix)**


