### PR TITLE
snapshot: Update mcumgr to commit e64f5060bd from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcumgr
 
-This is mcumgr, version 0.1.0
+This is mcumgr, version 0.2.0
 
 mcumgr is a management library for 32-bit MCUs.   The goal of mcumgr is to
 define a common management infrastructure with pluggable transport and encoding

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -143,18 +143,19 @@ img_mgmt_state_set_pending(int slot, int permanent)
 
 done:
     /* Log the image hash if we know it. */
-    rc = img_mgmt_read_info(slot, NULL, hash, NULL);
-    if (rc != 0) {
+    if (img_mgmt_read_info(slot, NULL, hash, NULL)) {
         hashp = NULL;
     } else {
         hashp = hash;
     }
 
     if (permanent) {
-        return img_mgmt_impl_log_confirm(rc, hashp);
+        (void) img_mgmt_impl_log_confirm(rc, hashp);
     } else {
-        return img_mgmt_impl_log_pending(rc, hashp);
+        (void) img_mgmt_impl_log_pending(rc, hashp);
     }
+
+    return rc;
 }
 
 /**

--- a/repository.yml
+++ b/repository.yml
@@ -21,7 +21,8 @@ repo.name: apache-mynewt-mcumgr
 repo.versions:
     "0.0.0": "master"
     "0.1.0": "mcumgr_0_1_0_tag"
+    "0.2.0": "mcumgr_0_2_0_tag"
 
 
     "0-dev": "0.0.0"       # master
-    "0-latest": "0.1.0"    # latest release
+    "0-latest": "0.2.0"    # latest release


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr e289eaddc9b8e238b5683359a6b3207c70c2c0e7
and the current top of the upstream:
  apache/mynewt-mcumgr 64f5060bd8bb466367e0da94da8b425d5b9f6388

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>