### PR TITLE
snapshot: Update mcumgr to commit 4fa869142f from upstream

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -74,6 +74,7 @@ extern struct img_mgmt_state g_img_mgmt_state;
 
 /** Represents an individual upload request. */
 struct img_mgmt_upload_req {
+    unsigned long long int image;   /* 0 by default */
     unsigned long long int off;     /* -1 if unspecified */
     unsigned long long int size;    /* -1 if unspecified */
     size_t data_len;

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -314,6 +314,10 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
     
     rc = img_mgmt_impl_erase_slot();
 
+    if (!rc) {
+        img_mgmt_dfu_stopped();
+    }
+
     err = 0;
     err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
     err |= cbor_encode_int(&ctxt->encoder, rc);
@@ -394,42 +398,49 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
         .data_len = 0,
         .data_sha_len = 0,
         .upgrade = false,
+        .image = 0,
     };
 
     const struct cbor_attr_t off_attr[] = {
         [0] = {
+            .attribute = "image",
+            .type = CborAttrUnsignedIntegerType,
+            .addr.uinteger = &req.image,
+            .nodefault = true
+        },
+        [1] = {
             .attribute = "data",
             .type = CborAttrByteStringType,
             .addr.bytestring.data = req.img_data,
             .addr.bytestring.len = &req.data_len,
             .len = sizeof(req.img_data)
         },
-        [1] = {
+        [2] = {
             .attribute = "len",
             .type = CborAttrUnsignedIntegerType,
             .addr.uinteger = &req.size,
             .nodefault = true
         },
-        [2] = {
+        [3] = {
             .attribute = "off",
             .type = CborAttrUnsignedIntegerType,
             .addr.uinteger = &req.off,
             .nodefault = true
         },
-        [3] = {
+        [4] = {
             .attribute = "sha",
             .type = CborAttrByteStringType,
             .addr.bytestring.data = req.data_sha,
             .addr.bytestring.len = &req.data_sha_len,
             .len = sizeof(req.data_sha)
         },
-        [4] = {
+        [5] = {
             .attribute = "upgrade",
             .type = CborAttrBooleanType,
             .addr.boolean = &req.upgrade,
             .dflt.boolean = false,
         },
-        [5] = { 0 },
+        [6] = { 0 },
     };
     int rc;
     const char *errstr = NULL;

--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -2,13 +2,14 @@
 CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_L2CAP_TX_MTU=252
+CONFIG_BT_L2CAP_RX_MTU=252
 CONFIG_BT_RX_BUF_LEN=260
 
 # Enable the Bluetooth (unauthenticated) and shell mcumgr transports.

--- a/samples/smp_svr/zephyr/prj_tiny.conf
+++ b/samples/smp_svr/zephyr/prj_tiny.conf
@@ -6,13 +6,14 @@
 CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_L2CAP_TX_MTU=252
+CONFIG_BT_L2CAP_RX_MTU=252
 CONFIG_BT_RX_BUF_LEN=260
 
 # Enable the Bluetooth (unauthenticated) and UART mcumgr transports.


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 64f5060bd8bb466367e0da94da8b425d5b9f6388
and the current top of the upstream:
  apache/mynewt-mcumgr 4fa869142f16e00d42415bc6dbcb7f1f92ba4abd

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

The update brings following commits that affect Zephyr:
 - 4fa8691 zephyr: Allow to select slot for DFU as image
 - d8802de samples/smp_svr/zephyr: Update stack size
 - e71063a zephyr: Improve and rename img_mgmt_find_best_area_id
 - e215d26 zephyr: Check area id in erase slot processing
 - 71c76f5 zephyr: Upload should use g_img_mgmt_state
 - afa95ba cmd/img_mgmt: Call dfu stop cb on erase
 - 6a10fa6 img_mgmt: Add interpretation of "image" parameter
 - 757965c samples: smp_svr: zephyr: Update MTU Kconfig values