### PR TITLE
snapshot: Update mcumgr to commit 1e0f283c71 from upstream

### DIFF
--- a/transport/smp-console.md
+++ b/transport/smp-console.md
@@ -39,7 +39,7 @@ below:
 | ----- | ----------- |
 | 0x06 0x09 | Byte pair indicating the start of a packet. |
 | 0x04 0x14 | Byte pair indicating the start of a continuation frame. |
-| Packet length | The combined total length of the *unencoded* body. |
+| Packet length | The combined total length of the *unencoded* body plus the final CRC (2 bytes). Length is in Big-Endian format. |
 | Body | The actual SMP data (i.e., 8-byte header and CBOR key-value map). |
 | CRC16 | A CRC16 of the *unencoded* body of the entire packet.  This field is only present in the final frame of a packet. |
 | Newline | A 0x0a byte; terminates a frame. |


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 4fa869142f16e00d42415bc6dbcb7f1f92ba4abd
and the current top of the upstream:
  apache/mynewt-mcumgr 1e0f283c71d90ee3aa2ca2ca97db2bb824ffa34b

The update brings following commits that affect Zephyr:
 * [CONFIGURATION BUGFIX] 1e0f283c71 zephyr: Make direct image upload configurable 
 
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>