### PR TITLE
snapshot: Update mcumgr to commit 75d6f6ea from the upstream

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -20,6 +20,9 @@
 #ifndef H_IMG_MGMT_CONFIG_
 #define H_IMG_MGMT_CONFIG_
 
+/* Number of updatable images */
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER 1
+
 #if defined MYNEWT
 
 #include "syscfg/syscfg.h"
@@ -37,8 +40,8 @@
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
-
-#else
+#undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -98,11 +98,13 @@ int img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 
 /**
  * @brief Indicates the type of swap operation that will occur on the next
- * reboot, if any.
+ * reboot, if any, between provided slot and it's pair.
+ * Quering any slots of the same pair will give the same result.
  *
+ * @param image                 An slot number;
  * @return                      An IMG_MGMT_SWAP_TYPE_[...] code.
  */
-int img_mgmt_impl_swap_type(void);
+int img_mgmt_impl_swap_type(int slot);
 
 /**
  * Collects information about the specified image slot.

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -510,8 +510,10 @@ done:
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
+    assert(slot == 0 || slot == 1);
+
     switch (boot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -36,6 +36,29 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <img_mgmt/image.h>
 #include "../../../src/img_mgmt_priv.h"
 
+BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1 ||
+             (CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 &&
+              FLASH_AREA_LABEL_EXISTS(image_2) &&
+              FLASH_AREA_LABEL_EXISTS(image_3)),
+              "Missing partitions?");
+
+static int
+zephyr_img_mgmt_slot_to_image(int slot)
+{
+    switch (slot) {
+    case 0:
+    case 1:
+        return 0;
+#if FLASH_AREA_LABEL_EXISTS(image_2) && FLASH_AREA_LABEL_EXISTS(image_3)
+    case 2:
+    case 3:
+        return 1;
+#endif
+    default:
+        assert(0);
+    }
+    return 0;
+}
 /**
  * Determines if the specified area of flash is completely unwritten.
  */
@@ -130,6 +153,7 @@ zephyr_img_mgmt_flash_area_id(int slot)
     return fa_id;
 }
 
+#if CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1
 /**
  * In normal operation this function will select between first two slot
  * (in reality it just checks whether second slot can be used), ignoring the
@@ -175,6 +199,27 @@ img_mgmt_get_unused_slot_area_id(int slot)
     return slot != -1  ? zephyr_img_mgmt_flash_area_id(slot) : -1;
 #endif
 }
+#elif CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2
+static int
+img_mgmt_get_unused_slot_area_id(int image)
+{
+    int area_id = -1;
+
+    if (image == 0) {
+        if (img_mgmt_slot_in_use(1) == 0) {
+            area_id = zephyr_img_mgmt_flash_area_id(1);
+        }
+    } else if (image == 1) {
+        area_id = zephyr_img_mgmt_flash_area_id(3);
+    } else {
+        assert(0);
+    }
+
+    return area_id;
+}
+#else
+#error "Unsupported number of images"
+#endif
 
 /**
  * Compares two image version numbers in a semver-compatible way.
@@ -243,11 +288,13 @@ img_mgmt_impl_write_pending(int slot, bool permanent)
 {
     int rc;
 
-    if (slot != 1) {
+    if (slot != 1 &&
+        !(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 && slot == 3)) {
         return MGMT_ERR_EINVAL;
     }
 
-    rc = boot_request_upgrade(permanent);
+    rc = boot_request_upgrade_multi(zephyr_img_mgmt_slot_to_image(slot),
+                                    permanent);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }
@@ -424,9 +471,11 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
-    switch (mcuboot_swap_type()) {
+    int image = zephyr_img_mgmt_slot_to_image(slot);
+
+    switch (mcuboot_swap_type_multi(image)) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;
     case BOOT_SWAP_TYPE_TEST:

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -241,7 +241,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
     int i;
     struct image_version ver;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
             continue;
         }
@@ -262,7 +262,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
     int i;
     uint8_t hash[IMAGE_HASH_LEN];
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
             continue;
         }


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 1e0f283c71d90ee3aa2ca2ca97db2bb824ffa34b
and the current top of the upstream:
  apache/mynewt-mcumgr 75d6f6ea7b05895e654513fecd598a7229df427b

The update contains following changes from upstream:
 - 75d6f6e, 7407858, ade68f8 Multi-image support

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>