### PR TITLE
snapshot: Update mcumgr to commit edb485cf from the upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ not require MCUboot.
 
 The `mcumgr` command line tool is available at:
 https://github.com/apache/mynewt-mcumgr-cli.  The command line tool requires [Go
-1.7 or later](https://golang.org/dl/).  Once Go is installed and set up on your
+1.12 or later](https://golang.org/dl/).  Once Go is installed and set up on your
 system, you can install the mcumgr CLI tool by issuing the following `go get`
 command:
 

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -40,8 +40,12 @@
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
+#ifdef CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+/* Up to two images are supported */
+BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 2, "Unsupported number of images");
 #undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#endif
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -515,6 +515,8 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
             }
         }
 #endif
+    } else {
+        cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_ONGOING;
     }
 
     /* Write the image data to flash. */
@@ -542,7 +544,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
             if (g_img_mgmt_state.off == g_img_mgmt_state.size) {
                 /* Done */
                 img_mgmt_dfu_pending();
-                cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_ONGOING;
+                cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE;
                 g_img_mgmt_state.area_id = -1;
             }
         }

--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -3,6 +3,7 @@ CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+CONFIG_MAIN_STACK_SIZE=2048
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 75d6f6ea7b05895e654513fecd598a7229df427b
and the current top of the upstream:
  apache/mynewt-mcumgr edb485cf471be3bc998b5c48866399a8a336ace5

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>