### PR TITLE
snapshot: Update mcumgr to commit 47fdde0c from the upstream

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -42,14 +42,16 @@
 #define IMG_MGMT_BOOT_CURR_SLOT 0
 #ifdef CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 /* Up to two images are supported */
-BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 2, "Unsupported number of images");
 #undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #endif
 
+#else
+
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.
  */
+#error "Unknown OS/missing configuration"
 
 #endif
 


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr edb485cf471be3bc998b5c48866399a8a336ace5
and the current top of the upstream:
  apache/mynewt-mcumgr 47fdde0c9a2bac821d2a814541e31d734dd78866

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>