### PR TITLE
snapshot: Update mcumgr to commit 12b496e3 from the upstream

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -306,7 +306,7 @@ cbor_internal_read_object(CborValue *root_value,
                 err |= CborErrorIllegalType;
             }
         }
-        cbor_value_advance(&cur_value);
+        err = cbor_value_advance(&cur_value);
     }
     if (!err) {
         /* that should be it for this container */

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -22,6 +22,8 @@
 
 /* Number of updatable images */
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER 1
+/* Image status list will only contain image attributes that are true/non-zero */
+#define IMG_MGMT_FRUGAL_LIST    0
 
 #if defined MYNEWT
 
@@ -44,6 +46,10 @@
 /* Up to two images are supported */
 #undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#endif
+#ifdef CONFIG_IMG_MGMT_FRUGAL_LIST
+#undef IMG_MGMT_FRUGAL_LIST
+#define IMG_MGMT_FRUGAL_LIST    CONFIG_IMG_MGMT_FRUGAL_LIST
 #endif
 
 #else

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -181,7 +181,7 @@ img_mgmt_get_unused_slot_area_id(int slot)
         for (slot = 0; slot < 2; slot++) {
             if (img_mgmt_slot_in_use(slot) == 0) {
                 int area_id = zephyr_img_mgmt_flash_area_id(slot);
-                if (area_id != -1) {
+                if (area_id >= 0) {
                     return area_id;
                 }
             }
@@ -319,8 +319,13 @@ img_mgmt_impl_read(int slot, unsigned int offset, void *dst,
 {
     const struct flash_area *fa;
     int rc;
+    int area_id = zephyr_img_mgmt_flash_area_id(slot);
 
-    rc = flash_area_open(zephyr_img_mgmt_flash_area_id(slot), &fa);
+    if (area_id < 0) {
+       return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = flash_area_open(area_id, &fa);
     if (rc != 0) {
       return MGMT_ERR_EUNKNOWN;
     }
@@ -682,8 +687,13 @@ img_mgmt_impl_erased_val(int slot, uint8_t *erased_val)
 {
     const struct flash_area *fa;
     int rc;
+    int area_id = zephyr_img_mgmt_flash_area_id(slot);
 
-    rc = flash_area_open(zephyr_img_mgmt_flash_area_id(slot), &fa);
+    if (area_id < 0) {
+      return MGMT_ERR_EUNKNOWN;
+    }
+
+    rc = flash_area_open(area_id, &fa);
     if (rc != 0) {
       return MGMT_ERR_EUNKNOWN;
     }

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -229,32 +229,47 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
         err |= cbor_encode_text_stringz(&image, "hash");
         err |= cbor_encode_byte_string(&image, hash, IMAGE_HASH_LEN);
 
-        err |= cbor_encode_text_stringz(&image, "bootable");
-        err |= cbor_encode_boolean(&image, !(flags & IMAGE_F_NON_BOOTABLE));
+        if (!IMG_MGMT_FRUGAL_LIST || !(flags & IMAGE_F_NON_BOOTABLE)) {
+            err |= cbor_encode_text_stringz(&image, "bootable");
+            err |= cbor_encode_boolean(&image, !(flags & IMAGE_F_NON_BOOTABLE));
+        }
 
-        err |= cbor_encode_text_stringz(&image, "pending");
-        err |= cbor_encode_boolean(&image,
-                                     state_flags & IMG_MGMT_STATE_F_PENDING);
+        if (!IMG_MGMT_FRUGAL_LIST || (state_flags & IMG_MGMT_STATE_F_PENDING)) {
+            err |= cbor_encode_text_stringz(&image, "pending");
+            err |= cbor_encode_boolean(&image,
+                                    state_flags & IMG_MGMT_STATE_F_PENDING);
+        }
 
-        err |= cbor_encode_text_stringz(&image, "confirmed");
-        err |= cbor_encode_boolean(&image,
-                                     state_flags & IMG_MGMT_STATE_F_CONFIRMED);
+        if (!IMG_MGMT_FRUGAL_LIST ||
+            (state_flags & IMG_MGMT_STATE_F_CONFIRMED)) {
+            err |= cbor_encode_text_stringz(&image, "confirmed");
+            err |= cbor_encode_boolean(&image,
+                                    state_flags & IMG_MGMT_STATE_F_CONFIRMED);
+        }
 
-        err |= cbor_encode_text_stringz(&image, "active");
-        err |= cbor_encode_boolean(&image,
-                                     state_flags & IMG_MGMT_STATE_F_ACTIVE);
+        if (!IMG_MGMT_FRUGAL_LIST || (state_flags & IMG_MGMT_STATE_F_ACTIVE)) {
+            err |= cbor_encode_text_stringz(&image, "active");
+            err |= cbor_encode_boolean(&image,
+                                    state_flags & IMG_MGMT_STATE_F_ACTIVE);
+        }
 
-        err |= cbor_encode_text_stringz(&image, "permanent");
-        err |= cbor_encode_boolean(&image,
-                                     state_flags & IMG_MGMT_STATE_F_PERMANENT);
+        if (!IMG_MGMT_FRUGAL_LIST ||
+            (state_flags & IMG_MGMT_STATE_F_PERMANENT)) {
+            err |= cbor_encode_text_stringz(&image, "permanent");
+            err |= cbor_encode_boolean(&image,
+                                    state_flags & IMG_MGMT_STATE_F_PERMANENT);
+        }
 
         err |= cbor_encoder_close_container(&images, &image);
     }
 
     err |= cbor_encoder_close_container(&ctxt->encoder, &images);
 
-    err |= cbor_encode_text_stringz(&ctxt->encoder, "splitStatus");
-    err |= cbor_encode_int(&ctxt->encoder, 0);
+    /* splitStatus is always 0 so in frugal list it is not present at all */
+    if (!IMG_MGMT_FRUGAL_LIST) {
+        err |= cbor_encode_text_stringz(&ctxt->encoder, "splitStatus");
+        err |= cbor_encode_int(&ctxt->encoder, 0);
+    }
 
     if (err != 0) {
         return MGMT_ERR_ENOMEM;


### PR DESCRIPTION
The commit applies changes that have appeared between the last snapshot
update from the upstream:
  apache/mynewt-mcumgr 47fdde0c9a2bac821d2a814541e31d734dd78866
and the current top of the upstream:
  apache/mynewt-mcumgr 12b496e37caf20a45ab5aee4209b06c5d79ef9b1

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>